### PR TITLE
feat: proposal for new library architecture 

### DIFF
--- a/lib/src/main/java/ru/vsu/cs/course2/a1pha/linear_algebra/vec/Vec.java
+++ b/lib/src/main/java/ru/vsu/cs/course2/a1pha/linear_algebra/vec/Vec.java
@@ -1,0 +1,37 @@
+package ru.vsu.cs.course2.a1pha.linear_algebra.vec;
+
+public final class Vec implements Vector {
+
+    private final float[] values;
+
+    public Vec(final float... values) {
+        this.values = new float[values.length];
+
+        for (int i = 0; i < values.length; i++) {
+            this.values[i] = values[i];
+        }
+    }
+
+    @Override
+    public float get(final int index) {
+        if (index < 0 || index >= size()) {
+            throw new IllegalArgumentException("Vec::get: index out of bounds");
+        }
+
+        return values[index];
+    }
+
+    @Override
+    public void set(final int index, final float value) {
+        if (index < 0 || index >= size()) {
+            throw new IllegalArgumentException("Vec::set: index out of bounds");
+        }
+
+        values[index] = value;
+    }
+
+    @Override
+    public int size() {
+        return values.length;
+    }
+}

--- a/lib/src/main/java/ru/vsu/cs/course2/a1pha/linear_algebra/vec/Vec3.java
+++ b/lib/src/main/java/ru/vsu/cs/course2/a1pha/linear_algebra/vec/Vec3.java
@@ -1,0 +1,65 @@
+package ru.vsu.cs.course2.a1pha.linear_algebra.vec;
+
+public final class Vec3 implements Vector3 {
+
+    private final float[] values = new float[3];
+
+    public Vec3(final float x, final float y, final float z) {
+        setX(x);
+        setY(y);
+        setZ(z);
+    }
+
+    @Override
+    public float get(final int index) {
+        if (index < 0 || index > 2) {
+            throw new IllegalArgumentException("Vec3::get: index out of bounds");
+        }
+
+        return values[index];
+    }
+
+    @Override
+    public void set(final int index, final float value) {
+        if (index < 0 || index > 2) {
+            throw new IllegalArgumentException("Vec3::get: index out of bounds");
+        }
+
+        values[index] = value;
+    }
+
+    @Override
+    public int size() {
+        return 3;
+    }
+
+    @Override
+    public float x() {
+        return values[0];
+    }
+
+    @Override
+    public void setX(final float value) {
+        values[0] = value;
+    }
+
+    @Override
+    public float y() {
+        return values[1];
+    }
+
+    @Override
+    public void setY(final float value) {
+        values[1] = value;
+    }
+
+    @Override
+    public float z() {
+        return values[2];
+    }
+
+    @Override
+    public void setZ(final float value) {
+        values[2] = value;
+    }
+}

--- a/lib/src/main/java/ru/vsu/cs/course2/a1pha/linear_algebra/vec/Vec3.java
+++ b/lib/src/main/java/ru/vsu/cs/course2/a1pha/linear_algebra/vec/Vec3.java
@@ -22,7 +22,7 @@ public final class Vec3 implements Vector3 {
     @Override
     public void set(final int index, final float value) {
         if (index < 0 || index > 2) {
-            throw new IllegalArgumentException("Vec3::get: index out of bounds");
+            throw new IllegalArgumentException("Vec3::set: index out of bounds");
         }
 
         values[index] = value;

--- a/lib/src/main/java/ru/vsu/cs/course2/a1pha/linear_algebra/vec/Vector.java
+++ b/lib/src/main/java/ru/vsu/cs/course2/a1pha/linear_algebra/vec/Vector.java
@@ -1,0 +1,10 @@
+package ru.vsu.cs.course2.a1pha.linear_algebra.vec;
+
+public interface Vector {
+
+    public float get(final int index);
+
+    public void set(final int index, final float value);
+
+    public int size();
+}

--- a/lib/src/main/java/ru/vsu/cs/course2/a1pha/linear_algebra/vec/Vector2.java
+++ b/lib/src/main/java/ru/vsu/cs/course2/a1pha/linear_algebra/vec/Vector2.java
@@ -1,0 +1,12 @@
+package ru.vsu.cs.course2.a1pha.linear_algebra.vec;
+
+public interface Vector2 extends Vector {
+
+    public float x();
+
+    public void setX(final float value);
+
+    public float y();
+
+    public void setY(final float value);
+}

--- a/lib/src/main/java/ru/vsu/cs/course2/a1pha/linear_algebra/vec/Vector2Math.java
+++ b/lib/src/main/java/ru/vsu/cs/course2/a1pha/linear_algebra/vec/Vector2Math.java
@@ -1,0 +1,23 @@
+package ru.vsu.cs.course2.a1pha.linear_algebra.vec;
+
+public final class Vector2Math {
+
+    public static void add(final Vector2 target, final Vector2 term) {
+        target.setX(target.x() + term.x());
+        target.setY(target.y() + term.y());
+    }
+
+    public static void subtract(final Vector2 target, final Vector2 term) {
+        target.setX(target.x() - term.x());
+        target.setY(target.y() - term.y());
+    }
+
+    public static float dot(final Vector2 v1, final Vector2 v2) {
+        float sum = 0;
+
+        sum += v1.x() * v2.x();
+        sum += v1.y() * v2.y();
+
+        return sum;
+    }
+}

--- a/lib/src/main/java/ru/vsu/cs/course2/a1pha/linear_algebra/vec/Vector3.java
+++ b/lib/src/main/java/ru/vsu/cs/course2/a1pha/linear_algebra/vec/Vector3.java
@@ -1,0 +1,16 @@
+package ru.vsu.cs.course2.a1pha.linear_algebra.vec;
+
+public interface Vector3 extends Vector {
+
+    public float x();
+
+    public void setX(final float value);
+
+    public float y();
+
+    public void setY(final float value);
+
+    public float z();
+
+    public void setZ(final float value);
+}

--- a/lib/src/main/java/ru/vsu/cs/course2/a1pha/linear_algebra/vec/Vector3Math.java
+++ b/lib/src/main/java/ru/vsu/cs/course2/a1pha/linear_algebra/vec/Vector3Math.java
@@ -1,0 +1,26 @@
+package ru.vsu.cs.course2.a1pha.linear_algebra.vec;
+
+public final class Vector3Math {
+
+    public static void add(final Vector3 target, final Vector3 term) {
+        target.setX(target.x() + term.x());
+        target.setY(target.y() + term.y());
+        target.setZ(target.z() + term.z());
+    }
+
+    public static void subtract(final Vector3 target, final Vector3 term) {
+        target.setX(target.x() - term.x());
+        target.setY(target.y() - term.y());
+        target.setZ(target.z() - term.z());
+    }
+
+    public static float dot(final Vector3 v1, final Vector3 v2) {
+        float sum = 0;
+
+        sum += v1.x() * v2.x();
+        sum += v1.y() * v2.y();
+        sum += v1.z() * v2.z();
+
+        return sum;
+    }
+}

--- a/lib/src/main/java/ru/vsu/cs/course2/a1pha/linear_algebra/vec/Vector3Math.java
+++ b/lib/src/main/java/ru/vsu/cs/course2/a1pha/linear_algebra/vec/Vector3Math.java
@@ -23,4 +23,12 @@ public final class Vector3Math {
 
         return sum;
     }
+
+    public static Vector3 cross(final Vector3 v1, final Vector3 v2) {
+        final float x = v1.z() * v2.y() - v1.y() * v2.z();
+        final float y = v1.x() * v2.z() - v1.z() * v2.x();
+        final float z = v1.y() * v2.x() - v1.x() * v2.y();
+
+        return new Vec3(x, y, z);
+    }
 }

--- a/lib/src/main/java/ru/vsu/cs/course2/a1pha/linear_algebra/vec/Vector4.java
+++ b/lib/src/main/java/ru/vsu/cs/course2/a1pha/linear_algebra/vec/Vector4.java
@@ -1,0 +1,20 @@
+package ru.vsu.cs.course2.a1pha.linear_algebra.vec;
+
+public interface Vector4 extends Vector {
+
+    public float x();
+
+    public void setX(final float value);
+
+    public float y();
+
+    public void setY(final float value);
+
+    public float z();
+
+    public void setZ(final float value);
+
+    public float w();
+
+    public void setW(final float value);
+}

--- a/lib/src/main/java/ru/vsu/cs/course2/a1pha/linear_algebra/vec/VectorMath.java
+++ b/lib/src/main/java/ru/vsu/cs/course2/a1pha/linear_algebra/vec/VectorMath.java
@@ -60,7 +60,6 @@ public final class VectorMath {
         final float value2 = v1.get(0) * v2.get(2) - v1.get(2) * v2.get(0);
         final float value3 = v1.get(1) * v2.get(0) - v1.get(0) * v2.get(1);
 
-        // TODO
-        return null;
+        return new Vec(value1, value2, value3);
     }
 }

--- a/lib/src/main/java/ru/vsu/cs/course2/a1pha/linear_algebra/vec/VectorMath.java
+++ b/lib/src/main/java/ru/vsu/cs/course2/a1pha/linear_algebra/vec/VectorMath.java
@@ -30,7 +30,7 @@ public final class VectorMath {
         final int size = v1.size();
 
         if (size != v2.size()) {
-            throw new IllegalArgumentException("VectorMath::subtract: vector sizes are not equal");
+            throw new IllegalArgumentException("VectorMath::dot: vector sizes are not equal");
         }
 
         float sum = 0;

--- a/lib/src/main/java/ru/vsu/cs/course2/a1pha/linear_algebra/vec/VectorMath.java
+++ b/lib/src/main/java/ru/vsu/cs/course2/a1pha/linear_algebra/vec/VectorMath.java
@@ -1,0 +1,44 @@
+package ru.vsu.cs.course2.a1pha.linear_algebra.vec;
+
+public final class VectorMath {
+
+    public static void add(final Vector target, final Vector term) {
+        final int size = target.size();
+
+        if (size != term.size()) {
+            throw new IllegalArgumentException("VectorMath::add: vector sizes are not equal");
+        }
+
+        for (int i = 0; i < size; i++) {
+            target.set(i, target.get(i) + term.get(i));
+        }
+    }
+
+    public static void subtract(final Vector target, final Vector term) {
+        final int size = target.size();
+
+        if (size != term.size()) {
+            throw new IllegalArgumentException("VectorMath::subtract: vector sizes are not equal");
+        }
+
+        for (int i = 0; i < size; i++) {
+            target.set(i, target.get(i) - term.get(i));
+        }
+    }
+
+    public static float dot(final Vector v1, final Vector v2) {
+        final int size = v1.size();
+
+        if (size != v2.size()) {
+            throw new IllegalArgumentException("VectorMath::subtract: vector sizes are not equal");
+        }
+
+        float sum = 0;
+
+        for (int i = 0; i < size; i++) {
+            sum += v1.get(i) * v2.get(i);
+        }
+
+        return sum;
+    }
+}

--- a/lib/src/main/java/ru/vsu/cs/course2/a1pha/linear_algebra/vec/VectorMath.java
+++ b/lib/src/main/java/ru/vsu/cs/course2/a1pha/linear_algebra/vec/VectorMath.java
@@ -41,4 +41,26 @@ public final class VectorMath {
 
         return sum;
     }
+
+    public static Vector cross(final Vector v1, final Vector v2) {
+        final int size = v1.size();
+
+        if (size != v2.size()) {
+            throw new IllegalArgumentException("VectorMath::cross: vector sizes are not equal");
+        }
+
+        // TODO
+        // probably should be a OperationNotSupportedException.
+        // also, more vector sizes can be supported (at least size == 2).
+        if (size != 3) {
+            throw new IllegalArgumentException("VectorMath::cross: vector sizes are not 3");
+        }
+
+        final float value1 = v1.get(2) * v2.get(1) - v1.get(1) * v2.get(2);
+        final float value2 = v1.get(0) * v2.get(2) - v1.get(2) * v2.get(0);
+        final float value3 = v1.get(1) * v2.get(0) - v1.get(0) * v2.get(1);
+
+        // TODO
+        return null;
+    }
 }


### PR DESCRIPTION
in my opinion, `Vector` interface in the `vectors` package does have too many methods.  if the user wants to implement this interface to use with the library, the library itself can calculate the result incorrectly, because the implemented methods are not required to give the correct result only from an interface.

so i propose that `Vector` only contains methods to represent the vector as an array. all methods with calculations are located in the `VectorMath` class.

but there is a problem. yes, premature optimization is not good overall, but with the linear algebra operations we should avoid the check as much as possible. because of that, some vector interfaces with common sizes (2, 3, 4) are present with corresponding classes for the calculations. they don't check the vector for the operations.

also, for performance and "no positive value" reason, there is no point in containing another vector with composition in strict (e.g. `Vector2`) implementations. there is some DRY, but overall it only makes the class more complicated.

everything was done in the separate `vec` package. not all classes are implemented: i have only implemented some of them as an example. also, this architecture can be applied to matrices, and i strongly advise that.