### PR TITLE
fix: correct gradle import

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Maven example for `pom.xml`:
 Gradle (Kotlin) example for `build.gradle.kts`:
 
 ```kts
-implementation("io.github.alphameo:linear-algebra:1.0.0")
+implementation("io.github.alphameo:linear_algebra:1.0.0")
 ```
 
 ### Manual Build


### PR DESCRIPTION
it currently has a dash instead of an underscore, and the package cannot be imported