### PR TITLE
docs: add since to javadoc

### DIFF
--- a/lib/src/main/java/io/github/alphameo/linear_algebra/Copyable.java
+++ b/lib/src/main/java/io/github/alphameo/linear_algebra/Copyable.java
@@ -4,6 +4,8 @@ package io.github.alphameo.linear_algebra;
  * Interface for copyable entities.
  * 
  * @param <T> class for copying
+ *
+ * @since 1.0.0
  */
 public interface Copyable<T> {
 
@@ -11,6 +13,8 @@ public interface Copyable<T> {
      * Copies object values into new object of same class.
      * 
      * @return copy of object
+     *
+     * @since 1.0.0
      */
     T copy();
 }

--- a/lib/src/main/java/io/github/alphameo/linear_algebra/Equatable.java
+++ b/lib/src/main/java/io/github/alphameo/linear_algebra/Equatable.java
@@ -4,6 +4,8 @@ package io.github.alphameo.linear_algebra;
  * Interface for equatable entities by its number values.
  * 
  * @param <T> class for comparison
+ *
+ * @since 1.0.0
  */
 public interface Equatable<T> {
 
@@ -15,6 +17,8 @@ public interface Equatable<T> {
      * @param eps   tolerance
      * @return {@code true} if number values of objects are equal within
      *         {@code epsilon} tolerance, and {@code false} otherwise
+     *
+     * @since 1.0.0
      */
     boolean equalsEpsilonTo(T other, float eps);
 
@@ -24,6 +28,8 @@ public interface Equatable<T> {
      * @param other object for comparison
      * @return {@code true} if number values of objects are approximately equal, and
      *         {@code false} otherwise
+     *
+     * @since 1.0.0
      */
     boolean equalsTo(T other);
 }

--- a/lib/src/main/java/io/github/alphameo/linear_algebra/Validator.java
+++ b/lib/src/main/java/io/github/alphameo/linear_algebra/Validator.java
@@ -5,17 +5,23 @@ import io.github.alphameo.linear_algebra.vec.Vector;
 
 /**
  * Class with static functions of validation
+ *
+ * @since 1.0.0
  */
 public class Validator {
 
     /**
      * Default empty constructor
+     *
+     * @since 1.0.0
      */
     public Validator() {
     }
 
     /**
      * Default value tolerance.
+     *
+     * @since 1.0.0
      */
     public static final float EPS = 0.000001f;
 
@@ -24,6 +30,8 @@ public class Validator {
      * 
      * @param divisor divisor value
      * @throws ArithmeticException if divisot approximately equals 0
+     *
+     * @since 1.0.0
      */
     public static void validateDivisor(final float divisor) throws ArithmeticException {
 
@@ -39,6 +47,8 @@ public class Validator {
      * @param v2         second vector for validation
      * @param errMessage specific message
      * @throws IllegalArgumentException if vector sizes are different
+     *
+     * @since 1.0.0
      */
     public static void validateVectorSizes(final Vector v1, final Vector v2,
             final String errMessage) throws IllegalArgumentException {
@@ -55,6 +65,8 @@ public class Validator {
      * @param m2         second matrix for validation
      * @param errMessage specific message
      * @throws IllegalArgumentException if vector sizes are different
+     *
+     * @since 1.0.0
      */
     public static void validateMatrixSizes(final Matrix m1, final Matrix m2,
             final String errMessage) {
@@ -72,6 +84,8 @@ public class Validator {
      * @param eps    tolerance
      * @return {@code true} if values are equal within {@code epsilon} tolerance,
      *         and {@code false} otherwise
+     *
+     * @since 1.0.0
      */
     public static boolean equalsEpsilon(float value1, float value2, float eps) {
         return Math.abs(value1 - value2) < eps;
@@ -84,6 +98,8 @@ public class Validator {
      * @param value2 second value for comparison
      * @return {@code true} if values are approximately equal, and {@code false}
      *         otherwise
+     *
+     * @since 1.0.0
      */
     public static boolean equals(float value1, float value2) {
         return Math.abs(value1 - value2) < EPS;

--- a/lib/src/main/java/io/github/alphameo/linear_algebra/mat/Mat.java
+++ b/lib/src/main/java/io/github/alphameo/linear_algebra/mat/Mat.java
@@ -8,6 +8,8 @@ import io.github.alphameo.linear_algebra.vec.Vector;
 
 /**
  * Default implementation of arbitrary matrix ({@code Matrix interface}).
+ *
+ * @since 1.0.0
  */
 public class Mat implements Matrix, Equatable<Matrix>, Copyable<Mat> {
 
@@ -18,6 +20,8 @@ public class Mat implements Matrix, Equatable<Matrix>, Copyable<Mat> {
      * 
      * @param height height of matrix for construction
      * @param width  width of matrix for construction
+     *
+     * @since 1.0.0
      */
     public Mat(final int height, final int width) {
         entries = new float[height][width];
@@ -27,6 +31,8 @@ public class Mat implements Matrix, Equatable<Matrix>, Copyable<Mat> {
      * Constructs new square matrix {@code size} x {@code size} with all 0.
      * 
      * @param size height and width of matrix for construction
+     *
+     * @since 1.0.0
      */
     public Mat(final int size) {
         this(size, size);
@@ -38,6 +44,8 @@ public class Mat implements Matrix, Equatable<Matrix>, Copyable<Mat> {
      * @param entries values for matrix elements
      * @throws IllegalArgumentException if given two dimensional array cannot be
      *                                  interpreted as rectangular matrix
+     *
+     * @since 1.0.0
      */
     public Mat(final float[][] entries) throws IllegalArgumentException {
         this(entries.length, entries[0].length);
@@ -54,6 +62,8 @@ public class Mat implements Matrix, Equatable<Matrix>, Copyable<Mat> {
      * Copies given matrix values into new matrix.
      * 
      * @param m matrix for copying
+     *
+     * @since 1.0.0
      */
     public Mat(final Matrix m) {
         entries = new float[m.height()][m.width()];
@@ -88,6 +98,8 @@ public class Mat implements Matrix, Equatable<Matrix>, Copyable<Mat> {
      * Transposes current matrix.
      *
      * @return current transposed matrix
+     *
+     * @since 1.0.0
      */
     public Matrix transpose() {
         final float[][] result = new float[entries[0].length][entries.length];
@@ -105,6 +117,8 @@ public class Mat implements Matrix, Equatable<Matrix>, Copyable<Mat> {
      * Construts transposed matrix from current matrix.
      *
      * @return new matrix, which is result of transposing of current square matrix
+     *
+     * @since 1.0.0
      */
     public Matrix transposed() {
         return MatMath.transposed(this);
@@ -117,6 +131,8 @@ public class Mat implements Matrix, Equatable<Matrix>, Copyable<Mat> {
      * @param r2 second index of row for swapping
      * @return current matrix with swapped rows
      * @throws ArrayIndexOutOfBoundsException if any row index is out of bounds
+     *
+     * @since 1.0.0
      */
     public Matrix swapRows(final int r1, final int r2) throws ArrayIndexOutOfBoundsException {
         return MatMath.swapRows(this, r1, r2);
@@ -129,6 +145,8 @@ public class Mat implements Matrix, Equatable<Matrix>, Copyable<Mat> {
      * @param r2 second index of row for swapping
      * @return new matrix with swapped rows of curren matrix
      * @throws ArrayIndexOutOfBoundsException if any row index is out of bounds
+     *
+     * @since 1.0.0
      */
     public Matrix swapppedRows(final int r1, final int r2) throws ArrayIndexOutOfBoundsException {
         return MatMath.swappedRows(this, r1, r2);
@@ -141,6 +159,8 @@ public class Mat implements Matrix, Equatable<Matrix>, Copyable<Mat> {
      * @param c2 second index of column for swapping
      * @return current matrix with swapped columns
      * @throws ArrayIndexOutOfBoundsException if any column index is out of bounds
+     *
+     * @since 1.0.0
      */
     public Matrix swapCols(final int c1, final int c2) throws ArrayIndexOutOfBoundsException {
         return MatMath.swapCols(this, c1, c2);
@@ -153,6 +173,8 @@ public class Mat implements Matrix, Equatable<Matrix>, Copyable<Mat> {
      * @param c2 second index of column for swapping
      * @return new matrix with swapped columns of current matrix
      * @throws ArrayIndexOutOfBoundsException if any column index is out of bounds
+     *
+     * @since 1.0.0
      */
     public Matrix swappedCols(final int c1, final int c2) throws ArrayIndexOutOfBoundsException {
         return MatMath.swappedCols(this, c1, c2);
@@ -163,6 +185,8 @@ public class Mat implements Matrix, Equatable<Matrix>, Copyable<Mat> {
      * 
      * @param multiplier scalar value
      * @return current matrix with multiplied elements
+     *
+     * @since 1.0.0
      */
     public Matrix mult(final float multiplier) {
         return MatMath.mult(this, multiplier);
@@ -173,6 +197,8 @@ public class Mat implements Matrix, Equatable<Matrix>, Copyable<Mat> {
      * 
      * @param multiplier scalar value
      * @return new matrix with multiplied elements of current matrix
+     *
+     * @since 1.0.0
      */
     public Matrix multiplied(final float multiplier) {
         return MatMath.multiplied(this, multiplier);
@@ -184,6 +210,8 @@ public class Mat implements Matrix, Equatable<Matrix>, Copyable<Mat> {
      * @param divisor scalar value
      * @return current matrix with divided elements
      * @throws ArithmeticException if {@code divisor} approximately equals 0
+     *
+     * @since 1.0.0
      */
     public Matrix divide(final float divisor) throws ArithmeticException {
         return MatMath.divide(this, divisor);
@@ -195,6 +223,8 @@ public class Mat implements Matrix, Equatable<Matrix>, Copyable<Mat> {
      * @param divisor scalar value
      * @return new matrix with divided elements of current matrix
      * @throws ArithmeticException if {@code divisor} approximately equals 0
+     *
+     * @since 1.0.0
      */
     public Matrix divided(final float divisor) throws ArithmeticException {
         return MatMath.divided(this, divisor);
@@ -207,6 +237,8 @@ public class Mat implements Matrix, Equatable<Matrix>, Copyable<Mat> {
      * @param addendum matrix to add
      * @return current matrix increased by {@code addendum} matrix
      * @throws IllegalArgumentException if matrices have different sizes
+     *
+     * @since 1.0.0
      */
     public Matrix add(final Matrix addendum) {
         return MatMath.add(this, addendum);
@@ -220,6 +252,8 @@ public class Mat implements Matrix, Equatable<Matrix>, Copyable<Mat> {
      * @return new matrix with sum of elements of current matrix and
      *         {@code addendum} matrix
      * @throws IllegalArgumentException if matrices have different sizes
+     *
+     * @since 1.0.0
      */
     public Matrix added(final Matrix addendum) {
         return MatMath.added(this, addendum);
@@ -232,6 +266,8 @@ public class Mat implements Matrix, Equatable<Matrix>, Copyable<Mat> {
      * @param subtrahend matrix to subtract
      * @return current matrix subtracted by {@code addendum} matrix
      * @throws IllegalArgumentException if matrices have different sizes
+     *
+     * @since 1.0.0
      */
     public Matrix sub(final Matrix subtrahend) {
         return MatMath.sub(this, subtrahend);
@@ -244,6 +280,8 @@ public class Mat implements Matrix, Equatable<Matrix>, Copyable<Mat> {
      * @param subtrahend matrix to subtract
      * @return current matrix subtracted by {@code addendum} matrix
      * @throws IllegalArgumentException if matrices have different sizes
+     *
+     * @since 1.0.0
      */
     public Matrix subtracted(final Matrix subtrahend) {
         return MatMath.subtracted(this, subtrahend);
@@ -256,6 +294,8 @@ public class Mat implements Matrix, Equatable<Matrix>, Copyable<Mat> {
      * @return matrix, which represents product of matrices
      * @throws IllegalArgumentException if the first matrix width is not equal to
      *                                  the second matrix height
+     *
+     * @since 1.0.0
      */
     public Matrix prod(final Matrix m) {
         return MatMath.prod(this, m);
@@ -268,6 +308,8 @@ public class Mat implements Matrix, Equatable<Matrix>, Copyable<Mat> {
      * @return vector, which represents product of current matrix and given vector
      * @throws IllegalArgumentException if width of the matrix is not equal to the
      *                                  vector size
+     *
+     * @since 1.0.0
      */
     public Vector prod(final Vector v) {
         return MatMath.prod(this, v);
@@ -277,6 +319,8 @@ public class Mat implements Matrix, Equatable<Matrix>, Copyable<Mat> {
      * Triangulates current matrix.
      * 
      * @return current matrix, which is triangulated
+     *
+     * @since 1.0.0
      */
     public Matrix triangulate() {
         return MatMath.triangulate(this);
@@ -286,6 +330,8 @@ public class Mat implements Matrix, Equatable<Matrix>, Copyable<Mat> {
      * Copies current matrix and triangulates it.
      * 
      * @return new matrix, which is result of triangulating of current matrix
+     *
+     * @since 1.0.0
      */
     public Matrix triangulated() {
         return MatMath.triangulated(this);
@@ -296,6 +342,8 @@ public class Mat implements Matrix, Equatable<Matrix>, Copyable<Mat> {
      * 
      * @return matrix determinant
      * @throws UnsupportedOperationException if matrix is not square
+     *
+     * @since 1.0.0
      */
     public float detThroughtCofactors() {
         return MatMath.detThroughCofactors(this);
@@ -306,6 +354,8 @@ public class Mat implements Matrix, Equatable<Matrix>, Copyable<Mat> {
      * 
      * @return matrix determinant
      * @throws UnsupportedOperationException if matrix is not square
+     *
+     * @since 1.0.0
      */
     public float det() {
         return MatMath.det(this);
@@ -317,6 +367,8 @@ public class Mat implements Matrix, Equatable<Matrix>, Copyable<Mat> {
      * @return invertible matrix
      * @throws UnsupportedOperationException if matrix is not square
      * @throws RuntimeException              if matrix determinant equals to 0
+     *
+     * @since 1.0.0
      */
     public Matrix invertible() {
         return MatMath.invertible(this);
@@ -329,6 +381,8 @@ public class Mat implements Matrix, Equatable<Matrix>, Copyable<Mat> {
      * @param c column index to exclude
      * @return minor matrix excluding given row and column
      * @throws UnsupportedOperationException if matrix is not square
+     *
+     * @since 1.0.0
      */
     public Matrix minorMatrix(final int r, final int c) {
         return MatMath.minorMatrix(this, r, c);
@@ -342,6 +396,8 @@ public class Mat implements Matrix, Equatable<Matrix>, Copyable<Mat> {
      * @param c index of column for cofactor calculation
      * @return cofactor value from given positions in current matrix
      * @throws UnsupportedOperationException if matrix is not square
+     *
+     * @since 1.0.0
      */
     public float cofactor(final int r, final int c) {
         return MatMath.cofactor(this, r, c);
@@ -352,6 +408,8 @@ public class Mat implements Matrix, Equatable<Matrix>, Copyable<Mat> {
      * 
      * @return matrix of cofactors
      * @throws UnsupportedOperationException if matrix is not square
+     *
+     * @since 1.0.0
      */
     public Matrix cofactorMatrix() {
         final Matrix result = new Mat(this.height(), this.width());
@@ -364,6 +422,8 @@ public class Mat implements Matrix, Equatable<Matrix>, Copyable<Mat> {
      * Returns {@code true} if matrix is square.
      * 
      * @return {@code true} if matrix is square, and {@code false} otherwise
+     *
+     * @since 1.0.0
      */
     public boolean square() {
         return MatMath.square(this);
@@ -374,6 +434,8 @@ public class Mat implements Matrix, Equatable<Matrix>, Copyable<Mat> {
      * 
      * @return {@code true} if matrix elements are approximately equal 0, and
      *         {@code false} otherwise
+     *
+     * @since 1.0.0
      */
     public boolean isZeroed() {
         return MatMath.isZeroed(this);
@@ -384,6 +446,8 @@ public class Mat implements Matrix, Equatable<Matrix>, Copyable<Mat> {
      * 
      * @return {@code true} if matrix is square diagonal, and {@code false}
      *         otherwise
+     *
+     * @since 1.0.0
      */
     public boolean diagonal() {
         return MatMath.diagonal(this);
@@ -446,6 +510,8 @@ public class Mat implements Matrix, Equatable<Matrix>, Copyable<Mat> {
      * @param height height of matrix to be constructed
      * @param width  width of matrix to be constructed
      * @return matrix {@code height} x {@code width} with all 0 elements
+     *
+     * @since 1.0.0
      */
     public static Matrix zeroMat(final int height, final int width) {
         return MatMath.zeroMat(height, width);
@@ -456,6 +522,8 @@ public class Mat implements Matrix, Equatable<Matrix>, Copyable<Mat> {
      * 
      * @param size height and width of matrix to be constructed
      * @return square matrix {@code size} x {@code size} with 1 on main diagonal
+     *
+     * @since 1.0.0
      */
     public static Matrix unitMat(final int size) {
         return MatMath.unitMat(size);

--- a/lib/src/main/java/io/github/alphameo/linear_algebra/mat/Mat3.java
+++ b/lib/src/main/java/io/github/alphameo/linear_algebra/mat/Mat3.java
@@ -8,6 +8,8 @@ import io.github.alphameo.linear_algebra.vec.Vector3;
 
 /**
  * Default implementation of matrix 3x3 ({@code Matrix3 interface}).
+ *
+ * @since 1.0.0
  */
 public class Mat3 implements Matrix3, Equatable<Matrix3>, Copyable<Mat3> {
 
@@ -15,6 +17,8 @@ public class Mat3 implements Matrix3, Equatable<Matrix3>, Copyable<Mat3> {
 
     /**
      * Constructs new matrix 3x3 with all 0.
+     *
+     * @since 1.0.0
      */
     public Mat3() {
         this.entries = new float[3][3];
@@ -32,6 +36,8 @@ public class Mat3 implements Matrix3, Equatable<Matrix3>, Copyable<Mat3> {
      * @param m20 element under row = 2, column = 0
      * @param m21 element under row = 2, column = 1
      * @param m22 element under row = 2, column = 2
+     *
+     * @since 1.0.0
      */
     public Mat3(
             final float m00, final float m01, final float m02,
@@ -55,6 +61,8 @@ public class Mat3 implements Matrix3, Equatable<Matrix3>, Copyable<Mat3> {
      * @param entries values for matrix elements
      * @throws IllegalArgumentException if given two dimensional array cannot be
      *                                  interpreted as matrix 3x3
+     *
+     * @since 1.0.0
      */
     public Mat3(final float entries[][]) {
         this();
@@ -76,6 +84,8 @@ public class Mat3 implements Matrix3, Equatable<Matrix3>, Copyable<Mat3> {
      * Copies given matrix 3x3 values into new matrix 3x3.
      * 
      * @param m matrix 3x3 for copying
+     *
+     * @since 1.0.0
      */
     public Mat3(final Matrix3 m) {
         this();
@@ -134,6 +144,8 @@ public class Mat3 implements Matrix3, Equatable<Matrix3>, Copyable<Mat3> {
      * Transposes current matrix.
      *
      * @return current transposed matrix
+     *
+     * @since 1.0.0
      */
     public Matrix3 transpose() {
         return Mat3Math.transpose(this);
@@ -143,6 +155,8 @@ public class Mat3 implements Matrix3, Equatable<Matrix3>, Copyable<Mat3> {
      * Construts transposed matrix from current matrix.
      *
      * @return new matrix, which is result of transposing of current square matrix
+     *
+     * @since 1.0.0
      */
     public Matrix3 transposed() {
         return Mat3Math.transposed(this);
@@ -154,6 +168,8 @@ public class Mat3 implements Matrix3, Equatable<Matrix3>, Copyable<Mat3> {
      * @param r1 first row for swapping
      * @param r2 second row for swapping
      * @return current matrix with swapped rows
+     *
+     * @since 1.0.0
      */
     public Matrix3 swapRows(final Matrix3Row r1, final Matrix3Row r2) {
         return Mat3Math.swapRows(this, r1, r2);
@@ -166,6 +182,8 @@ public class Mat3 implements Matrix3, Equatable<Matrix3>, Copyable<Mat3> {
      * @param r2 second index of row for swapping
      * @return current matrix with swapped rows
      * @throws ArrayIndexOutOfBoundsException if any row index is out of bounds
+     *
+     * @since 1.0.0
      */
     public Matrix3 swapRows(final int r1, final int r2) throws ArrayIndexOutOfBoundsException {
         return Mat3Math.swapRows(this, r1, r2);
@@ -177,6 +195,8 @@ public class Mat3 implements Matrix3, Equatable<Matrix3>, Copyable<Mat3> {
      * @param r1 first row for swapping
      * @param r2 second row for swapping
      * @return new matrix with swapped rows of curren matrix
+     *
+     * @since 1.0.0
      */
     public Matrix3 swappedRows(final Matrix3Row r1, final Matrix3Row r2) {
         return Mat3Math.swappedRows(this, r1, r2);
@@ -189,6 +209,8 @@ public class Mat3 implements Matrix3, Equatable<Matrix3>, Copyable<Mat3> {
      * @param r2 second index of row for swapping
      * @return new matrix with swapped rows of curren matrix
      * @throws ArrayIndexOutOfBoundsException if any row index is out of bounds
+     *
+     * @since 1.0.0
      */
     public Matrix3 swappedRows(final int r1, final int r2) throws ArrayIndexOutOfBoundsException {
         return Mat3Math.swappedRows(this, r1, r2);
@@ -200,6 +222,8 @@ public class Mat3 implements Matrix3, Equatable<Matrix3>, Copyable<Mat3> {
      * @param c1 first column for swapping
      * @param c2 second column for swapping
      * @return current matrix with swapped columns
+     *
+     * @since 1.0.0
      */
     public Matrix3 swapCols(final Matrix3Col c1, final Matrix3Col c2) {
         return Mat3Math.swapCols(this, c1, c2);
@@ -212,6 +236,8 @@ public class Mat3 implements Matrix3, Equatable<Matrix3>, Copyable<Mat3> {
      * @param c2 second index of column for swapping
      * @return current matrix with swapped columns
      * @throws ArrayIndexOutOfBoundsException if any column index is out of bounds
+     *
+     * @since 1.0.0
      */
     public Matrix3 swapCols(final int c1, final int c2) throws ArrayIndexOutOfBoundsException {
         return Mat3Math.swapCols(this, c1, c2);
@@ -223,6 +249,8 @@ public class Mat3 implements Matrix3, Equatable<Matrix3>, Copyable<Mat3> {
      * @param c1 first column for swapping
      * @param c2 second column for swapping
      * @return new matrix with swapped columns of current matrix
+     *
+     * @since 1.0.0
      */
     public Matrix3 swappedCols(final Matrix3Col c1, final Matrix3Col c2) {
         return Mat3Math.swappedCols(this, c1, c2);
@@ -235,6 +263,8 @@ public class Mat3 implements Matrix3, Equatable<Matrix3>, Copyable<Mat3> {
      * @param c2 second index of column for swapping
      * @return new matrix with swapped columns of current matrix
      * @throws ArrayIndexOutOfBoundsException if any column index is out of bounds
+     *
+     * @since 1.0.0
      */
     public Matrix3 swappedCols(final int c1, final int c2) throws ArrayIndexOutOfBoundsException {
         return Mat3Math.swappedCols(this, c1, c2);
@@ -245,6 +275,8 @@ public class Mat3 implements Matrix3, Equatable<Matrix3>, Copyable<Mat3> {
      * 
      * @param multiplier scalar value
      * @return current matrix with multiplied elements
+     *
+     * @since 1.0.0
      */
     public Matrix3 mult(final float multiplier) {
         return Mat3Math.mult(this, multiplier);
@@ -255,6 +287,8 @@ public class Mat3 implements Matrix3, Equatable<Matrix3>, Copyable<Mat3> {
      * 
      * @param multiplier scalar value
      * @return new matrix with multiplied elements of current matrix
+     *
+     * @since 1.0.0
      */
     public Matrix3 multiplied(final float multiplier) {
         return Mat3Math.multiplied(this, multiplier);
@@ -266,6 +300,8 @@ public class Mat3 implements Matrix3, Equatable<Matrix3>, Copyable<Mat3> {
      * @param divisor scalar value
      * @return current matrix with divided elements
      * @throws ArithmeticException if {@code divisor} approximately equals 0
+     *
+     * @since 1.0.0
      */
     public Matrix3 divide(final float divisor) throws ArithmeticException {
         return Mat3Math.divide(this, divisor);
@@ -277,6 +313,8 @@ public class Mat3 implements Matrix3, Equatable<Matrix3>, Copyable<Mat3> {
      * @param divisor scalar value
      * @return new matrix with divided elements of current matrix
      * @throws ArithmeticException if {@code divisor} approximately equals 0
+     *
+     * @since 1.0.0
      */
     public Matrix3 divided(final float divisor) throws ArithmeticException {
         return Mat3Math.divided(this, divisor);
@@ -288,6 +326,8 @@ public class Mat3 implements Matrix3, Equatable<Matrix3>, Copyable<Mat3> {
      * 
      * @param addendum matrix 3x3 to add
      * @return current matrix increased by {@code addendum} matrix
+     *
+     * @since 1.0.0
      */
     public Matrix3 add(final Matrix3 addendum) {
         return Mat3Math.add(this, addendum);
@@ -300,6 +340,8 @@ public class Mat3 implements Matrix3, Equatable<Matrix3>, Copyable<Mat3> {
      * @param addendum matrix 3x3 to add
      * @return new matrix with sum of elements of current matrix and
      *         {@code addendum} matrix
+     *
+     * @since 1.0.0
      */
     public Matrix3 added(final Matrix3 addendum) {
         return Mat3Math.added(this, addendum);
@@ -311,6 +353,8 @@ public class Mat3 implements Matrix3, Equatable<Matrix3>, Copyable<Mat3> {
      * 
      * @param subtrahend matrix 3x3 to subtract
      * @return current matrix subtracted by {@code addendum} matrix
+     *
+     * @since 1.0.0
      */
     public Matrix3 sub(final Matrix3 subtrahend) {
         return Mat3Math.sub(this, subtrahend);
@@ -322,6 +366,8 @@ public class Mat3 implements Matrix3, Equatable<Matrix3>, Copyable<Mat3> {
      * 
      * @param subtrahend matrix 3x3 to subtract
      * @return current matrix subtracted by {@code addendum} matrix
+     *
+     * @since 1.0.0
      */
     public Matrix3 subtracted(final Matrix3 subtrahend) {
         return Mat3Math.subtracted(this, subtrahend);
@@ -332,6 +378,8 @@ public class Mat3 implements Matrix3, Equatable<Matrix3>, Copyable<Mat3> {
      *
      * @param m second (right) matrix 3x3
      * @return matrix, which represents product of matrices
+     *
+     * @since 1.0.0
      */
     public Matrix3 prod(final Matrix3 m) {
         return Mat3Math.prod(this, m);
@@ -343,6 +391,8 @@ public class Mat3 implements Matrix3, Equatable<Matrix3>, Copyable<Mat3> {
      * @param v column vector of size 3 (right)
      * @return vector of size 3, which represents product of current matrix and
      *         given vector
+     *
+     * @since 1.0.0
      */
     public Vector3 prod(final Vector3 v) {
         return Mat3Math.prod(this, v);
@@ -352,6 +402,8 @@ public class Mat3 implements Matrix3, Equatable<Matrix3>, Copyable<Mat3> {
      * Triangulates current matrix.
      * 
      * @return current matrix, which is triangulated
+     *
+     * @since 1.0.0
      */
     public Matrix3 triangulate() {
         return Mat3Math.triangulate(this);
@@ -361,6 +413,8 @@ public class Mat3 implements Matrix3, Equatable<Matrix3>, Copyable<Mat3> {
      * Copies current matrix and triangulates it.
      * 
      * @return new matrix, which is result of triangulating of current matrix
+     *
+     * @since 1.0.0
      */
     public Matrix3 triangulated() {
         return Mat3Math.triangulated(this);
@@ -370,6 +424,8 @@ public class Mat3 implements Matrix3, Equatable<Matrix3>, Copyable<Mat3> {
      * Calculates matrix determinant.
      * 
      * @return matrix determinant
+     *
+     * @since 1.0.0
      */
     public float det() {
         return Mat3Math.det(this);
@@ -380,6 +436,8 @@ public class Mat3 implements Matrix3, Equatable<Matrix3>, Copyable<Mat3> {
      *
      * @return invertible matrix
      * @throws RuntimeException if matrix determinant equals to 0
+     *
+     * @since 1.0.0
      */
     public Matrix3 invertible() {
         return Mat3Math.invertible(this);
@@ -392,6 +450,8 @@ public class Mat3 implements Matrix3, Equatable<Matrix3>, Copyable<Mat3> {
      * @param r row to exclude
      * @param c column to exclude
      * @return minor matrix excluding given row and column
+     *
+     * @since 1.0.0
      */
     public Matrix minorMatrix(final Matrix3Row r, final Matrix3Col c) {
         return Mat3Math.minorMatrix(this, r, c);
@@ -403,6 +463,8 @@ public class Mat3 implements Matrix3, Equatable<Matrix3>, Copyable<Mat3> {
      * @param r row index to exclude
      * @param c column index to exclude
      * @return minor matrix excluding given row and column
+     *
+     * @since 1.0.0
      */
     public Matrix minorMatrix(final int r, final int c) {
         return Mat3Math.minorMatrix(this, r, c);
@@ -415,6 +477,8 @@ public class Mat3 implements Matrix3, Equatable<Matrix3>, Copyable<Mat3> {
      * @param r index of row for cofactor calculation
      * @param c index of column for cofactor calculation
      * @return cofactor value from given positions in current matrix
+     *
+     * @since 1.0.0
      */
     public float cofactor(final Matrix3Row r, final Matrix3Col c) {
         return Mat3Math.cofactor(this, r, c);
@@ -427,6 +491,8 @@ public class Mat3 implements Matrix3, Equatable<Matrix3>, Copyable<Mat3> {
      * @param r index of row for cofactor calculation
      * @param c index of column for cofactor calculation
      * @return cofactor value from given positions in current matrix
+     *
+     * @since 1.0.0
      */
     public float cofactor(final int r, final int c) {
         return Mat3Math.cofactor(this, r, c);
@@ -436,6 +502,8 @@ public class Mat3 implements Matrix3, Equatable<Matrix3>, Copyable<Mat3> {
      * Constructs matrix of cofactors (algebraic complements)
      * 
      * @return matrix of cofactors
+     *
+     * @since 1.0.0
      */
     public Matrix3 cofactorMatrix() {
         return Mat3Math.cofactorMatrix(this);
@@ -445,6 +513,8 @@ public class Mat3 implements Matrix3, Equatable<Matrix3>, Copyable<Mat3> {
      * Returns true, because matrix is square.
      * 
      * @return {@code true}
+     *
+     * @since 1.0.0
      */
     public boolean square() {
         return true;
@@ -455,6 +525,8 @@ public class Mat3 implements Matrix3, Equatable<Matrix3>, Copyable<Mat3> {
      * 
      * @return {@code true} if matrix elements are approximately equal 0, and
      *         {@code false} otherwise
+     *
+     * @since 1.0.0
      */
     public boolean isZeroed() {
         return Mat3Math.isZeroed(this);
@@ -465,6 +537,8 @@ public class Mat3 implements Matrix3, Equatable<Matrix3>, Copyable<Mat3> {
      * 
      * @return {@code true} if matrix is square diagonal, and {@code false}
      *         otherwise
+     *
+     * @since 1.0.0
      */
     public boolean diagonal() {
         return Mat3Math.diagonal(this);
@@ -484,6 +558,8 @@ public class Mat3 implements Matrix3, Equatable<Matrix3>, Copyable<Mat3> {
      * </pre>
      * 
      * @return new matrix 4x4
+     *
+     * @since 1.0.0
      */
     public Matrix4 toMat4() {
         return Mat3Math.toMat4(this);
@@ -506,6 +582,8 @@ public class Mat3 implements Matrix3, Equatable<Matrix3>, Copyable<Mat3> {
      * @param insertionRow row for insertion 0
      * @param insertionCol column for insertion 0
      * @return new matrix 4x4
+     *
+     * @since 1.0.0
      */
     public Matrix4 toMat4(final Matrix4Row insertionRow, final Matrix4Col insertionCol) {
         return Mat3Math.toMat4(this, insertionRow, insertionCol);
@@ -527,6 +605,8 @@ public class Mat3 implements Matrix3, Equatable<Matrix3>, Copyable<Mat3> {
      * @param insertionRow row index for insertion 0
      * @param insertionCol column index for insertion 0
      * @return new matrix 4x4
+     *
+     * @since 1.0.0
      */
     public Matrix4 toMat4(final int insertionRow, final int insertionCol) {
         return Mat3Math.toMat4(this, insertionRow, insertionCol);
@@ -587,6 +667,8 @@ public class Mat3 implements Matrix3, Equatable<Matrix3>, Copyable<Mat3> {
      * Constructs matrix 3x3 of with all 0 elements.
      * 
      * @return matrix 3x3 with all 0 elements
+     *
+     * @since 1.0.0
      */
     public static Matrix3 zeroMat() {
         return Mat3Math.zeroMat();
@@ -596,6 +678,8 @@ public class Mat3 implements Matrix3, Equatable<Matrix3>, Copyable<Mat3> {
      * Constructs square matrix 3x3 with 1 on main diagonal.
      * 
      * @return square matrix 3x3 with 1 on main diagonal
+     *
+     * @since 1.0.0
      */
     public static Matrix3 unitMat() {
         return Mat3Math.unitMat();

--- a/lib/src/main/java/io/github/alphameo/linear_algebra/mat/Mat3Math.java
+++ b/lib/src/main/java/io/github/alphameo/linear_algebra/mat/Mat3Math.java
@@ -9,22 +9,30 @@ import io.github.alphameo.linear_algebra.vec.Vector3;
 
 /**
  * Class with static functions for matrices 3x3.
+ *
+ * @since 1.0.0
  */
 public final class Mat3Math {
 
     /**
      * Default empty constructor
+     *
+     * @since 1.0.0
      */
     public Mat3Math() {
     }
 
     /**
      * Constant array of enums for fast and safe access to matrix 3x3 rows
+     *
+     * @since 1.0.0
      */
     public static final Matrix3Row[] ROWS = Matrix3Row.values();
 
     /**
      * Constant array of enums for fast and safe access to matrix 3x3 columns
+     *
+     * @since 1.0.0
      */
     public static final Matrix3Col[] COLS = Matrix3Col.values();
 
@@ -33,6 +41,8 @@ public final class Mat3Math {
      *
      * @param m matrix 3x3 for transpose
      * @return given matrix 3x3, which is transposed
+     *
+     * @since 1.0.0
      */
     public static Matrix3 transpose(final Matrix3 m) {
         float tmp;
@@ -52,6 +62,8 @@ public final class Mat3Math {
      * 
      * @param m matrix 3x3 for transpose
      * @return new matrix 3x3, which is result of transposing of given matrix 3x3
+     *
+     * @since 1.0.0
      */
     public static Matrix3 transposed(final Matrix3 m) {
         return transpose(new Mat3(m));
@@ -64,6 +76,8 @@ public final class Mat3Math {
      * @param r1 first row for swapping
      * @param r2 second row for swapping
      * @return given matrix 3x3 with swapped rows
+     *
+     * @since 1.0.0
      */
     public static Matrix3 swapRows(final Matrix3 m, final Matrix3Row r1, final Matrix3Row r2) {
         float tmp;
@@ -84,6 +98,8 @@ public final class Mat3Math {
      * @param r2 second index of row for swapping
      * @return given 3x3 matrix with swapped rows
      * @throws ArrayIndexOutOfBoundsException if any row index is out of bounds
+     *
+     * @since 1.0.0
      */
     public static Matrix3 swapRows(final Matrix3 m, final int r1, final int r2) throws ArrayIndexOutOfBoundsException {
         return swapRows(m, ROWS[r1], ROWS[r2]);
@@ -96,6 +112,8 @@ public final class Mat3Math {
      * @param r1 first row for swapping
      * @param r2 second row for swapping
      * @return new matrix 3x3 with swapped rows of given matrix 3x3
+     *
+     * @since 1.0.0
      */
     public static Matrix3 swappedRows(final Matrix3 m, final Matrix3Row r1, final Matrix3Row r2) {
         return swapRows(new Mat3(m), r1, r2);
@@ -109,6 +127,8 @@ public final class Mat3Math {
      * @param r2 second index of row for swapping
      * @return new matrix 3x3 with swapped rows of given matrix 3x3
      * @throws ArrayIndexOutOfBoundsException if any row index is out of bounds
+     *
+     * @since 1.0.0
      */
     public static Matrix3 swappedRows(final Matrix3 m, final int r1, final int r2)
             throws ArrayIndexOutOfBoundsException {
@@ -122,6 +142,8 @@ public final class Mat3Math {
      * @param c1 first column for swapping
      * @param c2 second column for swapping
      * @return given matrix 3x3 with swapped columns
+     *
+     * @since 1.0.0
      */
     public static Matrix3 swapCols(final Matrix3 m, final Matrix3Col c1, final Matrix3Col c2) {
         float tmp;
@@ -141,6 +163,8 @@ public final class Mat3Math {
      * @param c1 first index of column for swapping
      * @param c2 second index of column for swapping
      * @return given matrix 3x3 with swapped columns
+     *
+     * @since 1.0.0
      */
     public static Matrix3 swapCols(final Matrix3 m, final int c1, final int c2) {
         return swapCols(m, COLS[c1], COLS[c2]);
@@ -153,6 +177,8 @@ public final class Mat3Math {
      * @param c1 first column for swapping
      * @param c2 second column for swapping
      * @return new matrix 3x3 with swapped columns of given matrix 3x3
+     *
+     * @since 1.0.0
      */
     public static Matrix3 swappedCols(final Matrix3 m, final Matrix3Col c1, final Matrix3Col c2) {
         return swapCols(new Mat3(m), c1, c2);
@@ -166,6 +192,8 @@ public final class Mat3Math {
      * @param c2 second index of column for swapping
      * @return new matrix 3x3 with swapped columns of given matrix 3x3
      * @throws ArrayIndexOutOfBoundsException if any column index is out of bounds
+     *
+     * @since 1.0.0
      */
     public static Matrix3 swappedCols(final Matrix3 m, final int c1, final int c2)
             throws ArrayIndexOutOfBoundsException {
@@ -178,6 +206,8 @@ public final class Mat3Math {
      * @param m          matrix 3x3 for multiplication
      * @param multiplier scalar value
      * @return given matrix 3x3 with multiplied elements
+     *
+     * @since 1.0.0
      */
     public static Matrix3 mult(final Matrix3 m, final float multiplier) {
         for (final Matrix3Row r : ROWS) {
@@ -195,6 +225,8 @@ public final class Mat3Math {
      * @param m          matrix for multiplication
      * @param multiplier scalar value
      * @return new matrix 3x3 with multiplied elements of given matrix
+     *
+     * @since 1.0.0
      */
     public static Matrix3 multiplied(final Matrix3 m, final float multiplier) {
         return mult(new Mat3(m), multiplier);
@@ -207,6 +239,8 @@ public final class Mat3Math {
      * @param divisor scalar value
      * @return given matrix 3x3 with divided elements
      * @throws ArithmeticException if {@code divisor} approximately equals 0
+     *
+     * @since 1.0.0
      */
     public static Matrix3 divide(final Matrix3 m, final float divisor) throws ArithmeticException {
         Validator.validateDivisor(divisor);
@@ -226,6 +260,8 @@ public final class Mat3Math {
      * @param divisor scalar value
      * @return new matrix 3x3 with divided elements of given matrix
      * @throws ArithmeticException if {@code divisor} approximately equals 0
+     *
+     * @since 1.0.0
      */
     public static Matrix3 divided(final Matrix3 m, final float divisor) throws ArithmeticException {
         return divide(new Mat3(m), divisor);
@@ -238,6 +274,8 @@ public final class Mat3Math {
      * @param target   matrix 3x3 to be added
      * @param addendum matrix 3x3 to add
      * @return {@code target} matrix 3x3 increased by {@code addendum} matrix 3x3
+     *
+     * @since 1.0.0
      */
     public static Matrix3 add(final Matrix3 target, final Matrix3 addendum) {
         for (final Matrix3Row r : ROWS) {
@@ -257,6 +295,8 @@ public final class Mat3Math {
      * @param addendum matrix 3x3 to add
      * @return new matrix 3x3 with sum of elements of {@code target} matrix 3x3 and
      *         {@code addendum} matrix 3x3
+     *
+     * @since 1.0.0
      */
     public static Matrix3 added(final Matrix3 target, final Matrix3 addendum) {
         return add(new Mat3(target), addendum);
@@ -269,6 +309,8 @@ public final class Mat3Math {
      * @param target     matrix 3x3 to be subtracted
      * @param subtrahend matrix 3x3 to subtract
      * @return {@code target} matrix 3x3 subtracted by {@code addendum} matrix 3x3
+     *
+     * @since 1.0.0
      */
     public static Matrix3 sub(final Matrix3 target, final Matrix3 subtrahend) {
         for (final Matrix3Row r : ROWS) {
@@ -288,6 +330,8 @@ public final class Mat3Math {
      * @param subtrahend matrix 3x3 to subtract
      * @return new matrix 4x4 with components resulting {@code target} matrix 4x4
      *         subtracted by {@code subtrahend} matrix 4x4
+     *
+     * @since 1.0.0
      */
     public static Matrix3 subtracted(final Matrix3 target, final Matrix3 subtrahend) {
         return sub(new Mat3(target), subtrahend);
@@ -299,6 +343,8 @@ public final class Mat3Math {
      * @param m1 first (left) matrix 3x3
      * @param m2 second (right) matrix 3x3
      * @return matrix 3x3, which represents product of given matrices
+     *
+     * @since 1.0.0
      */
     public static Matrix3 prod(final Matrix3 m1, final Matrix3 m2) {
         final Matrix3 result = new Mat3();
@@ -321,6 +367,8 @@ public final class Mat3Math {
      * @param m matrix 3x3 (left)
      * @param v column vector of size 3 (right)
      * @return vector of size 3, which represents product of given matrix and vector
+     *
+     * @since 1.0.0
      */
     public static Vector3 prod(final Matrix3 m, final Vector3 v) {
         final Vector3 result = new Vec3();
@@ -341,6 +389,8 @@ public final class Mat3Math {
      * 
      * @param m matrix 3x3 to be triangulated
      * @return given matrix 3x3, which is triangulated
+     *
+     * @since 1.0.0
      */
     public static Matrix3 triangulate(final Matrix3 m) {
         int countOfSwaps = 0;
@@ -389,6 +439,8 @@ public final class Mat3Math {
      * 
      * @param m matrix 3x3 to be triangulated
      * @return new matrix 3x3, which is result of triangulating of given matrix 3x3
+     *
+     * @since 1.0.0
      */
     public static Matrix3 triangulated(final Matrix3 m) {
         return triangulate(new Mat3(m));
@@ -399,6 +451,8 @@ public final class Mat3Math {
      * 
      * @param m matrix 3x3 for determinant calculation
      * @return matrix 3x3 determinant
+     *
+     * @since 1.0.0
      */
     public static float det(final Matrix3 m) {
         return m.get(R0, C0) * m.get(R1, C1) * m.get(R2, C2)
@@ -415,6 +469,8 @@ public final class Mat3Math {
      * @param m matrix 3x3 for invertible matrix 3x3 construction
      * @return invertible matrix 3x3
      * @throws RuntimeException if matrix determinant equals to 0
+     *
+     * @since 1.0.0
      */
     public static Matrix3 invertible(final Matrix3 m) throws RuntimeException {
         final Matrix3 result = cofactorMatrix(m);
@@ -435,6 +491,8 @@ public final class Mat3Math {
      * @param r row to exclude
      * @param c column to exclude
      * @return minor matrix excluding given row and column
+     *
+     * @since 1.0.0
      */
     public static Matrix minorMatrix(final Matrix3 m, final Matrix3Row r, final Matrix3Col c) {
         final Matrix result = new Mat(2);
@@ -466,6 +524,8 @@ public final class Mat3Math {
      * @param r row index to exclude
      * @param c column index to exclude
      * @return minor matrix excluding given row and column
+     *
+     * @since 1.0.0
      */
     public static Matrix minorMatrix(final Matrix3 m, final int r, final int c) {
         return minorMatrix(m, ROWS[r], COLS[c]);
@@ -479,6 +539,8 @@ public final class Mat3Math {
      * @param r row for cofactor calculation
      * @param c column for cofactor calculation
      * @return cofactor value from given positions in given matrix 3x3
+     *
+     * @since 1.0.0
      */
     public static float cofactor(final Matrix3 m, final Matrix3Row r, final Matrix3Col c) {
         final int coefficient = (r.ordinal() + c.ordinal()) % 2 == 0 ? 1 : -1;
@@ -493,6 +555,8 @@ public final class Mat3Math {
      * @param r index of row for cofactor calculation
      * @param c index of column for cofactor calculation
      * @return cofactor value from given positions in given matrix 3x3
+     *
+     * @since 1.0.0
      */
     public static float cofactor(final Matrix3 m, final int r, final int c) {
         return cofactor(m, ROWS[r], COLS[c]);
@@ -503,6 +567,8 @@ public final class Mat3Math {
      * 
      * @param m matrix 3x3 for matrix of cofactors construction
      * @return matrix 3x3 of cofactors
+     *
+     * @since 1.0.0
      */
     public static Matrix3 cofactorMatrix(final Matrix3 m) {
         final Matrix3 result = new Mat3();
@@ -521,6 +587,8 @@ public final class Mat3Math {
      * @param m matrix 3x3 for analysis
      * @return {@code true} if matrix elements are approximately equal 0, and
      *         {@code false} otherwise
+     *
+     * @since 1.0.0
      */
     public static boolean isZeroed(final Matrix3 m) {
         for (final Matrix3Row r : ROWS) {
@@ -540,6 +608,8 @@ public final class Mat3Math {
      * @param m matrix for analysis
      * @return {@code true} if matrix is square diagonal, and {@code false}
      *         otherwise
+     *
+     * @since 1.0.0
      */
     public static boolean diagonal(final Matrix3 m) {
         for (final Matrix3Row r : ROWS) {
@@ -574,6 +644,8 @@ public final class Mat3Math {
      * @param insertionRow row for insertion 0
      * @param insertionCol column for insertion 0
      * @return new matrix 4x4
+     *
+     * @since 1.0.0
      */
     public static Matrix4 toMat4(final Matrix3 m, final Matrix4Row insertionRow, final Matrix4Col insertionCol) {
         final Matrix4 result = new Mat4();
@@ -620,6 +692,8 @@ public final class Mat3Math {
      * @param insertionCol column index for insertion 0
      * @return new matrix 4x4
      * @throws ArrayIndexOutOfBoundsException if any column index is out of bounds
+     *
+     * @since 1.0.0
      */
     public static Matrix4 toMat4(final Matrix3 m, final int insertionRow, final int insertionCol)
             throws ArrayIndexOutOfBoundsException {
@@ -644,6 +718,8 @@ public final class Mat3Math {
      * 
      * @param m matrix 3x3
      * @return new matrix 4x4
+     *
+     * @since 1.0.0
      */
     public static Matrix4 toMat4(final Matrix3 m) {
         return toMat4(m, Matrix4Row.R3, Matrix4Col.C3);
@@ -658,6 +734,8 @@ public final class Mat3Math {
      * @param eps tolerance
      * @return {@code true} if all elements of matrices 3x3 are equal within
      *         {@code epsilon} tolerance, and {@code false} otherwise
+     *
+     * @since 1.0.0
      */
     public static boolean equalsEpsilon(final Matrix3 m1, final Matrix3 m2, final float eps) {
         for (final Matrix3Row r : ROWS) {
@@ -678,6 +756,8 @@ public final class Mat3Math {
      * @param m2 second matrix 3x3 for comparison
      * @return {@code true} if all elements of matrices 3x3 are approximately equal,
      *         and {@code false} otherwise
+     *
+     * @since 1.0.0
      */
     public static boolean equals(final Matrix3 m1, final Matrix3 m2) {
         return equalsEpsilon(m1, m2, Validator.EPS);
@@ -687,6 +767,8 @@ public final class Mat3Math {
      * Constructs matrix 3x3 of with all 0 elements.
      * 
      * @return matrix 3x3 with all 0 elements
+     *
+     * @since 1.0.0
      */
     public static Matrix3 zeroMat() {
         return new Mat3();
@@ -696,6 +778,8 @@ public final class Mat3Math {
      * Constructs square matrix 3x3 with 1 on main diagonal.
      * 
      * @return square matrix 3x3 with 1 on main diagonal
+     *
+     * @since 1.0.0
      */
     public static Matrix3 unitMat() {
         final Matrix3 result = new Mat3();

--- a/lib/src/main/java/io/github/alphameo/linear_algebra/mat/Mat4.java
+++ b/lib/src/main/java/io/github/alphameo/linear_algebra/mat/Mat4.java
@@ -8,6 +8,8 @@ import io.github.alphameo.linear_algebra.vec.Vector4;
 
 /**
  * Default implementation of matrix 4x4 ({@code Matrix4 interface}).
+ *
+ * @since 1.0.0
  */
 public class Mat4 implements Matrix4, Equatable<Matrix4>, Copyable<Mat4> {
 
@@ -15,6 +17,8 @@ public class Mat4 implements Matrix4, Equatable<Matrix4>, Copyable<Mat4> {
 
     /**
      * Constructs new matrix 3x3 with all 0.
+     *
+     * @since 1.0.0
      */
     public Mat4() {
         this.entries = new float[4][4];
@@ -39,6 +43,8 @@ public class Mat4 implements Matrix4, Equatable<Matrix4>, Copyable<Mat4> {
      * @param m31 element under row = 3, column = 1
      * @param m32 element under row = 3, column = 2
      * @param m33 element under row = 3, column = 3
+     *
+     * @since 1.0.0
      */
     public Mat4(
             final float m00, final float m01, final float m02, final float m03,
@@ -70,6 +76,8 @@ public class Mat4 implements Matrix4, Equatable<Matrix4>, Copyable<Mat4> {
      * @param entries values for matrix elements
      * @throws IllegalArgumentException if given two dimensional array cannot be
      *                                  interpreted as matrix 4x4
+     *
+     * @since 1.0.0
      */
     public Mat4(final float entries[][]) throws IllegalArgumentException {
         this();
@@ -91,6 +99,8 @@ public class Mat4 implements Matrix4, Equatable<Matrix4>, Copyable<Mat4> {
      * Copies given matrix 4x4 values into new matrix 4x4.
      * 
      * @param m matrix 4x4 for copying
+     *
+     * @since 1.0.0
      */
     public Mat4(final Matrix4 m) {
         this();
@@ -149,6 +159,8 @@ public class Mat4 implements Matrix4, Equatable<Matrix4>, Copyable<Mat4> {
      * Transposes current matrix.
      *
      * @return current transposed matrix
+     *
+     * @since 1.0.0
      */
     public Matrix4 transpose() {
         return Mat4Math.transpose(this);
@@ -158,6 +170,8 @@ public class Mat4 implements Matrix4, Equatable<Matrix4>, Copyable<Mat4> {
      * Construts transposed matrix from current matrix.
      *
      * @return new matrix, which is result of transposing of current square matrix
+     *
+     * @since 1.0.0
      */
     public Matrix4 transposed() {
         return this.copy().transpose();
@@ -169,6 +183,8 @@ public class Mat4 implements Matrix4, Equatable<Matrix4>, Copyable<Mat4> {
      * @param r1 first row for swapping
      * @param r2 second row for swapping
      * @return current matrix with swapped rows
+     *
+     * @since 1.0.0
      */
     public Matrix4 swapRows(final Matrix4Row r1, final Matrix4Row r2) {
         return Mat4Math.swapRows(this, r1, r2);
@@ -181,6 +197,8 @@ public class Mat4 implements Matrix4, Equatable<Matrix4>, Copyable<Mat4> {
      * @param r2 second index of row for swapping
      * @return current matrix with swapped rows
      * @throws ArrayIndexOutOfBoundsException if any row index is out of bounds
+     *
+     * @since 1.0.0
      */
     public Matrix4 swapRows(final int r1, final int r2) throws ArrayIndexOutOfBoundsException {
         return Mat4Math.swapRows(this, r1, r2);
@@ -192,6 +210,8 @@ public class Mat4 implements Matrix4, Equatable<Matrix4>, Copyable<Mat4> {
      * @param r1 first row for swapping
      * @param r2 second row for swapping
      * @return new matrix with swapped rows of curren matrix
+     *
+     * @since 1.0.0
      */
     public Matrix4 swappedRows(final Matrix4Row r1, final Matrix4Row r2) {
         return Mat4Math.swappedRows(this, r1, r2);
@@ -204,6 +224,8 @@ public class Mat4 implements Matrix4, Equatable<Matrix4>, Copyable<Mat4> {
      * @param r2 second index of row for swapping
      * @return new matrix with swapped rows of curren matrix
      * @throws ArrayIndexOutOfBoundsException if any row index is out of bounds
+     *
+     * @since 1.0.0
      */
     public Matrix4 swappedRows(final int r1, final int r2) throws ArrayIndexOutOfBoundsException {
         return Mat4Math.swappedRows(this, r1, r2);
@@ -215,6 +237,8 @@ public class Mat4 implements Matrix4, Equatable<Matrix4>, Copyable<Mat4> {
      * @param c1 first column for swapping
      * @param c2 second column for swapping
      * @return current matrix with swapped columns
+     *
+     * @since 1.0.0
      */
     public Matrix4 swapCols(final Matrix4Col c1, final Matrix4Col c2) {
         return Mat4Math.swapCols(this, c1, c2);
@@ -227,6 +251,8 @@ public class Mat4 implements Matrix4, Equatable<Matrix4>, Copyable<Mat4> {
      * @param c2 second index of column for swapping
      * @return current matrix with swapped columns
      * @throws ArrayIndexOutOfBoundsException if any column index is out of bounds
+     *
+     * @since 1.0.0
      */
     public Matrix4 swapCols(final int c1, final int c2) throws ArrayIndexOutOfBoundsException {
         return Mat4Math.swapCols(this, c1, c2);
@@ -238,6 +264,8 @@ public class Mat4 implements Matrix4, Equatable<Matrix4>, Copyable<Mat4> {
      * @param c1 first column for swapping
      * @param c2 second column for swapping
      * @return new matrix with swapped columns of current matrix
+     *
+     * @since 1.0.0
      */
     public Matrix4 swappedCols(final Matrix4Col c1, final Matrix4Col c2) {
         return Mat4Math.swappedCols(this, c1, c2);
@@ -250,6 +278,8 @@ public class Mat4 implements Matrix4, Equatable<Matrix4>, Copyable<Mat4> {
      * @param c2 second index of column for swapping
      * @return new matrix with swapped columns of current matrix
      * @throws ArrayIndexOutOfBoundsException if any column index is out of bounds
+     *
+     * @since 1.0.0
      */
     public Matrix4 swappedCols(final int c1, final int c2) throws ArrayIndexOutOfBoundsException {
         return Mat4Math.swappedCols(this, c1, c2);
@@ -260,6 +290,8 @@ public class Mat4 implements Matrix4, Equatable<Matrix4>, Copyable<Mat4> {
      * 
      * @param multiplier scalar value
      * @return current matrix with multiplied elements
+     *
+     * @since 1.0.0
      */
     public Matrix4 mult(final float multiplier) {
         return Mat4Math.mult(this, multiplier);
@@ -270,6 +302,8 @@ public class Mat4 implements Matrix4, Equatable<Matrix4>, Copyable<Mat4> {
      * 
      * @param multiplier scalar value
      * @return new matrix with multiplied elements of current matrix
+     *
+     * @since 1.0.0
      */
     public Matrix4 multiplied(final float multiplier) {
         return Mat4Math.multiplied(this, multiplier);
@@ -281,6 +315,8 @@ public class Mat4 implements Matrix4, Equatable<Matrix4>, Copyable<Mat4> {
      * @param divisor scalar value
      * @return current matrix with divided elements
      * @throws ArithmeticException if {@code divisor} approximately equals 0
+     *
+     * @since 1.0.0
      */
     public Matrix4 divide(final float divisor) throws ArithmeticException {
         return Mat4Math.divide(this, divisor);
@@ -292,6 +328,8 @@ public class Mat4 implements Matrix4, Equatable<Matrix4>, Copyable<Mat4> {
      * @param divisor scalar value
      * @return new matrix with divided elements of current matrix
      * @throws ArithmeticException if {@code divisor} approximately equals 0
+     *
+     * @since 1.0.0
      */
     public Matrix4 divided(final float divisor) throws ArithmeticException {
         return Mat4Math.divide(this, divisor);
@@ -303,6 +341,8 @@ public class Mat4 implements Matrix4, Equatable<Matrix4>, Copyable<Mat4> {
      * 
      * @param addendum matrix 4x4 to add
      * @return current matrix increased by {@code addendum} matrix
+     *
+     * @since 1.0.0
      */
     public Matrix4 add(final Matrix4 addendum) {
         return Mat4Math.add(this, addendum);
@@ -315,6 +355,8 @@ public class Mat4 implements Matrix4, Equatable<Matrix4>, Copyable<Mat4> {
      * @param addendum matrix 4x4 to add
      * @return new matrix with sum of elements of current matrix and
      *         {@code addendum} matrix
+     *
+     * @since 1.0.0
      */
     public Matrix4 added(final Matrix4 addendum) {
         return Mat4Math.added(this, addendum);
@@ -326,6 +368,8 @@ public class Mat4 implements Matrix4, Equatable<Matrix4>, Copyable<Mat4> {
      * 
      * @param subtrahend matrix 4x4 to subtract
      * @return current matrix subtracted by {@code addendum} matrix
+     *
+     * @since 1.0.0
      */
     public Matrix4 sub(final Matrix4 subtrahend) {
         return Mat4Math.sub(this, subtrahend);
@@ -337,6 +381,8 @@ public class Mat4 implements Matrix4, Equatable<Matrix4>, Copyable<Mat4> {
      * 
      * @param subtrahend matrix 4x4 to subtract
      * @return current matrix subtracted by {@code addendum} matrix
+     *
+     * @since 1.0.0
      */
     public Matrix4 subtracted(final Matrix4 subtrahend) {
         return Mat4Math.subtracted(this, subtrahend);
@@ -347,6 +393,8 @@ public class Mat4 implements Matrix4, Equatable<Matrix4>, Copyable<Mat4> {
      *
      * @param m second (right) matrix 4x4
      * @return matrix, which represents product of matrices
+     *
+     * @since 1.0.0
      */
     public Matrix4 prod(final Matrix4 m) {
         return Mat4Math.prod(this, m);
@@ -358,6 +406,8 @@ public class Mat4 implements Matrix4, Equatable<Matrix4>, Copyable<Mat4> {
      * @param v column vector of size 4 (right)
      * @return vector of size 4, which represents product of current matrix and
      *         given vector
+     *
+     * @since 1.0.0
      */
     public Vector4 prod(final Vector4 v) {
         return Mat4Math.prod(this, v);
@@ -367,6 +417,8 @@ public class Mat4 implements Matrix4, Equatable<Matrix4>, Copyable<Mat4> {
      * Triangulates current matrix.
      * 
      * @return current matrix, which is triangulated
+     *
+     * @since 1.0.0
      */
     public Matrix4 triangulate() {
         return Mat4Math.triangulate(this);
@@ -376,6 +428,8 @@ public class Mat4 implements Matrix4, Equatable<Matrix4>, Copyable<Mat4> {
      * Copies current matrix and triangulates it.
      * 
      * @return new matrix, which is result of triangulating of current matrix
+     *
+     * @since 1.0.0
      */
     public Matrix4 triangulated() {
         return Mat4Math.triangulated(this);
@@ -385,6 +439,8 @@ public class Mat4 implements Matrix4, Equatable<Matrix4>, Copyable<Mat4> {
      * Calculates matrix determinant.
      * 
      * @return matrix determinant
+     *
+     * @since 1.0.0
      */
     public float det() {
         return Mat4Math.det(this);
@@ -395,6 +451,8 @@ public class Mat4 implements Matrix4, Equatable<Matrix4>, Copyable<Mat4> {
      *
      * @return invertible matrix
      * @throws RuntimeException if matrix determinant equals to 0
+     *
+     * @since 1.0.0
      */
     public Matrix4 invertible() throws RuntimeException {
         return Mat4Math.invertible(this);
@@ -407,6 +465,8 @@ public class Mat4 implements Matrix4, Equatable<Matrix4>, Copyable<Mat4> {
      * @param r row to exclude
      * @param c column to exclude
      * @return minor matrix excluding given row and column
+     *
+     * @since 1.0.0
      */
     public Matrix3 minorMatrix(final Matrix4Row r, final Matrix4Col c) {
         return Mat4Math.minorMatrix(this, r, c);
@@ -418,6 +478,8 @@ public class Mat4 implements Matrix4, Equatable<Matrix4>, Copyable<Mat4> {
      * @param r row index to exclude
      * @param c column index to exclude
      * @return minor matrix excluding given row and column
+     *
+     * @since 1.0.0
      */
     public Matrix3 minorMatrix(final int r, final int c) {
         return Mat4Math.minorMatrix(this, r, c);
@@ -430,6 +492,8 @@ public class Mat4 implements Matrix4, Equatable<Matrix4>, Copyable<Mat4> {
      * @param r index of row for cofactor calculation
      * @param c index of column for cofactor calculation
      * @return cofactor value from given positions in current matrix
+     *
+     * @since 1.0.0
      */
     public float cofactor(final Matrix4Row r, final Matrix4Col c) {
         return Mat4Math.cofactor(this, r, c);
@@ -442,6 +506,8 @@ public class Mat4 implements Matrix4, Equatable<Matrix4>, Copyable<Mat4> {
      * @param r index of row for cofactor calculation
      * @param c index of column for cofactor calculation
      * @return cofactor value from given positions in current matrix
+     *
+     * @since 1.0.0
      */
     public float cofactor(final int r, final int c) {
         return Mat4Math.cofactor(this, r, c);
@@ -451,6 +517,8 @@ public class Mat4 implements Matrix4, Equatable<Matrix4>, Copyable<Mat4> {
      * Constructs matrix of cofactors (algebraic complements)
      * 
      * @return matrix of cofactors
+     *
+     * @since 1.0.0
      */
     public Matrix4 cofactorMatrix() {
         return Mat4Math.cofactorMatrix(this);
@@ -460,6 +528,8 @@ public class Mat4 implements Matrix4, Equatable<Matrix4>, Copyable<Mat4> {
      * Returns true, because matrix is square.
      * 
      * @return {@code true}
+     *
+     * @since 1.0.0
      */
     public boolean square() {
         return true;
@@ -470,6 +540,8 @@ public class Mat4 implements Matrix4, Equatable<Matrix4>, Copyable<Mat4> {
      * 
      * @return {@code true} if matrix elements are approximately equal 0, and
      *         {@code false} otherwise
+     *
+     * @since 1.0.0
      */
     public boolean isZeroed() {
         return Mat4Math.isZeroed(this);
@@ -480,6 +552,8 @@ public class Mat4 implements Matrix4, Equatable<Matrix4>, Copyable<Mat4> {
      * 
      * @return {@code true} if matrix is square diagonal, and {@code false}
      *         otherwise
+     *
+     * @since 1.0.0
      */
     public boolean diagonal() {
         return Mat4Math.diagonal(this);
@@ -540,6 +614,8 @@ public class Mat4 implements Matrix4, Equatable<Matrix4>, Copyable<Mat4> {
      * Constructs matrix 4x4 of with all 0 elements.
      * 
      * @return matrix 4x4 with all 0 elements
+     *
+     * @since 1.0.0
      */
     public static Matrix4 zeroMat() {
         return Mat4Math.zeroMat();
@@ -549,6 +625,8 @@ public class Mat4 implements Matrix4, Equatable<Matrix4>, Copyable<Mat4> {
      * Constructs square matrix 4x4 with 1 on main diagonal.
      * 
      * @return square matrix 4x4 with 1 on main diagonal
+     *
+     * @since 1.0.0
      */
     public static Matrix4 unitMat() {
         return Mat4Math.unitMat();

--- a/lib/src/main/java/io/github/alphameo/linear_algebra/mat/Mat4Math.java
+++ b/lib/src/main/java/io/github/alphameo/linear_algebra/mat/Mat4Math.java
@@ -8,21 +8,29 @@ import io.github.alphameo.linear_algebra.vec.Vector4;
 
 /**
  * Class with static functions for matrices 4x4.
+ *
+ * @since 1.0.0
  */
 public final class Mat4Math {
 
     /**
      * Constant array of enums for fast and safe access to matrix 4x4 rows
+     *
+     * @since 1.0.0
      */
     public static final Matrix4Row[] ROWS = Matrix4Row.values();
 
     /**
      * Constant array of enums for fast and safe access to matrix 4x4 columns
+     *
+     * @since 1.0.0
      */
     public static final Matrix4Col[] COLS = Matrix4Col.values();
 
     /**
      * Default empty constructor
+     *
+     * @since 1.0.0
      */
     public Mat4Math() {
     }
@@ -32,6 +40,8 @@ public final class Mat4Math {
      *
      * @param m matrix 4x4 for transpose
      * @return given matrix 4x4, which is transposed
+     *
+     * @since 1.0.0
      */
     public static Matrix4 transpose(final Matrix4 m) {
         float tmp;
@@ -51,6 +61,8 @@ public final class Mat4Math {
      * 
      * @param m matrix 4x4 for transpose
      * @return new matrix 4x4, which is result of transposing of given matrix 4x4
+     *
+     * @since 1.0.0
      */
     public static Matrix4 transposed(final Matrix4 m) {
         return transpose(new Mat4(m));
@@ -63,6 +75,8 @@ public final class Mat4Math {
      * @param r1 first row for swapping
      * @param r2 second row for swapping
      * @return given matrix 4x4 with swapped rows
+     *
+     * @since 1.0.0
      */
     public static Matrix4 swapRows(final Matrix4 m, final Matrix4Row r1, final Matrix4Row r2) {
         float tmp;
@@ -83,6 +97,8 @@ public final class Mat4Math {
      * @param r2 second index of row for swapping
      * @return given 4x4 matrix with swapped rows
      * @throws ArrayIndexOutOfBoundsException if any row index is out of bounds
+     *
+     * @since 1.0.0
      */
     public static Matrix4 swapRows(final Matrix4 m, final int r1, final int r2) throws ArrayIndexOutOfBoundsException {
         swapRows(m, ROWS[r1], ROWS[r2]);
@@ -97,6 +113,8 @@ public final class Mat4Math {
      * @param r1 first row for swapping
      * @param r2 second row for swapping
      * @return new matrix 4x4 with swapped rows of given matrix 4x4
+     *
+     * @since 1.0.0
      */
     public static Matrix4 swappedRows(final Matrix4 m, final Matrix4Row r1, final Matrix4Row r2) {
         return swapRows(new Mat4(m), r1, r2);
@@ -110,6 +128,8 @@ public final class Mat4Math {
      * @param r2 second index of row for swapping
      * @return new matrix 4x4 with swapped rows of given matrix 4x4
      * @throws ArrayIndexOutOfBoundsException if any row index is out of bounds
+     *
+     * @since 1.0.0
      */
     public static Matrix4 swappedRows(final Matrix4 m, final int r1, final int r2)
             throws ArrayIndexOutOfBoundsException {
@@ -123,6 +143,8 @@ public final class Mat4Math {
      * @param c1 first column for swapping
      * @param c2 second column for swapping
      * @return given matrix 4x4 with swapped columns
+     *
+     * @since 1.0.0
      */
     public static Matrix4 swapCols(final Matrix4 m, final Matrix4Col c1, final Matrix4Col c2) {
         float tmp;
@@ -142,6 +164,8 @@ public final class Mat4Math {
      * @param c1 first index of column for swapping
      * @param c2 second index of column for swapping
      * @return given matrix 4x4 with swapped columns
+     *
+     * @since 1.0.0
      */
     public static Matrix4 swapCols(final Matrix4 m, final int c1, final int c2) {
         return swapCols(m, COLS[c1], COLS[c2]);
@@ -155,6 +179,8 @@ public final class Mat4Math {
      * @param c2 second column for swapping
      * @return new matrix 4x4 with swapped columns of given matrix 4x4
      * @throws ArrayIndexOutOfBoundsException if any column index is out of bounds
+     *
+     * @since 1.0.0
      */
     public static Matrix4 swappedCols(final Matrix4 m, final Matrix4Col c1, final Matrix4Col c2)
             throws ArrayIndexOutOfBoundsException {
@@ -169,6 +195,8 @@ public final class Mat4Math {
      * @param c2 second index of column for swapping
      * @return new matrix 4x4 with swapped columns of given matrix 4x4
      * @throws ArrayIndexOutOfBoundsException if any column index is out of bounds
+     *
+     * @since 1.0.0
      */
     public static Matrix4 swappedCols(final Matrix4 m, final int c1, final int c2)
             throws ArrayIndexOutOfBoundsException {
@@ -181,6 +209,8 @@ public final class Mat4Math {
      * @param m          matrix 4x4 for multiplication
      * @param multiplier scalar value
      * @return given matrix 4x4 with multiplied elements
+     *
+     * @since 1.0.0
      */
     public static Matrix4 mult(final Matrix4 m, final float multiplier) {
         for (final Matrix4Row r : ROWS) {
@@ -198,6 +228,8 @@ public final class Mat4Math {
      * @param m          matrix for multiplication
      * @param multiplier scalar value
      * @return new matrix 4x4 with multiplied elements of given matrix
+     *
+     * @since 1.0.0
      */
     public static Matrix4 multiplied(final Matrix4 m, final float multiplier) {
         return mult(new Mat4(m), multiplier);
@@ -210,6 +242,8 @@ public final class Mat4Math {
      * @param divisor scalar value
      * @return given matrix 4x4 with divided elements
      * @throws ArithmeticException if {@code divisor} approximately equals 0
+     *
+     * @since 1.0.0
      */
     public static Matrix4 divide(final Matrix4 m, final float divisor) throws ArithmeticException {
         Validator.validateDivisor(divisor);
@@ -229,6 +263,8 @@ public final class Mat4Math {
      * @param divisor scalar value
      * @return new matrix 4x4 with divided elements of given matrix
      * @throws ArithmeticException if {@code divisor} approximately equals 0
+     *
+     * @since 1.0.0
      */
     public static Matrix4 divided(final Matrix4 m, final float divisor) throws ArithmeticException {
         return divide(new Mat4(m), divisor);
@@ -241,6 +277,8 @@ public final class Mat4Math {
      * @param target   matrix 4x4 to be added
      * @param addendum matrix 4x4 to add
      * @return {@code target} matrix 4x4 increased by {@code addendum} matrix 4x4
+     *
+     * @since 1.0.0
      */
     public static Matrix4 add(final Matrix4 target, final Matrix4 addendum) {
         for (final Matrix4Row r : ROWS) {
@@ -260,6 +298,8 @@ public final class Mat4Math {
      * @param addendum matrix 4x4 to add
      * @return new matrix 4x4 with sum of elements of {@code target} matrix 4x4 and
      *         {@code addendum} matrix 4x4
+     *
+     * @since 1.0.0
      */
     public static Matrix4 added(final Matrix4 target, final Matrix4 addendum) {
         return add(new Mat4(target), addendum);
@@ -272,6 +312,8 @@ public final class Mat4Math {
      * @param target     matrix 4x4 to be subtracted
      * @param subtrahend matrix 4x4 to subtract
      * @return {@code target} matrix 4x4 subtracted by {@code addendum} matrix 4x4
+     *
+     * @since 1.0.0
      */
     public static Matrix4 sub(final Matrix4 target, final Matrix4 subtrahend) {
         for (final Matrix4Row r : ROWS) {
@@ -291,6 +333,8 @@ public final class Mat4Math {
      * @param subtrahend matrix 4x4 to subtract
      * @return new matrix 4x4 with components resulting {@code target} matrix 4x4
      *         subtracted by {@code subtrahend} matrix 4x4
+     *
+     * @since 1.0.0
      */
     public static Matrix4 subtracted(final Matrix4 target, final Matrix4 subtrahend) {
         return sub(new Mat4(target), subtrahend);
@@ -302,6 +346,8 @@ public final class Mat4Math {
      * @param m1 first (left) matrix 4x4
      * @param m2 second (right) matrix 4x4
      * @return matrix 4x4, which represents product of given matrices
+     *
+     * @since 1.0.0
      */
     public static Matrix4 prod(final Matrix4 m1, final Matrix4 m2) {
         final Matrix4 result = new Mat4();
@@ -324,6 +370,8 @@ public final class Mat4Math {
      * @param m matrix 4x4 (left)
      * @param v column vector of size 4 (right)
      * @return vector of size 4, which represents product of given matrix and vector
+     *
+     * @since 1.0.0
      */
     public static Vector4 prod(final Matrix4 m, final Vector4 v) {
         final Vector4 result = new Vec4();
@@ -344,6 +392,8 @@ public final class Mat4Math {
      * 
      * @param m matrix 4x4 to be triangulated
      * @return given matrix 4x4, which is triangulated
+     *
+     * @since 1.0.0
      */
     public static Matrix4 triangulate(final Matrix4 m) {
         int countOfSwaps = 0;
@@ -392,6 +442,8 @@ public final class Mat4Math {
      * 
      * @param m matrix 4x4 to be triangulated
      * @return new matrix 4x4, which is result of triangulating of given matrix 4x4
+     *
+     * @since 1.0.0
      */
     public static Matrix4 triangulated(final Matrix4 m) {
         return triangulate(new Mat4(m));
@@ -402,6 +454,8 @@ public final class Mat4Math {
      * 
      * @param m matrix 4x4 for determinant calculation
      * @return matrix 4x4 determinant
+     *
+     * @since 1.0.0
      */
     public static float det(final Matrix4 m) {
         float determinant = 0;
@@ -417,6 +471,8 @@ public final class Mat4Math {
      * @param m matrix 4x4 for invertible matrix 4x4 construction
      * @return invertible matrix 4x4
      * @throws RuntimeException if matrix determinant equals to 0
+     *
+     * @since 1.0.0
      */
     public static Matrix4 invertible(final Matrix4 m) throws RuntimeException {
         final Matrix4 result = cofactorMatrix(m);
@@ -437,6 +493,8 @@ public final class Mat4Math {
      * @param r row to exclude
      * @param c column to exclude
      * @return minor matrix excluding given row and column
+     *
+     * @since 1.0.0
      */
     public static Matrix3 minorMatrix(final Matrix4 m, final Matrix4Row r, final Matrix4Col c) {
         final Matrix3 result = new Mat3();
@@ -471,6 +529,8 @@ public final class Mat4Math {
      * @param r row index to exclude
      * @param c column index to exclude
      * @return minor matrix excluding given row and column
+     *
+     * @since 1.0.0
      */
     public static Matrix3 minorMatrix(final Matrix4 m, final int r, final int c) {
         return minorMatrix(m, ROWS[r], COLS[c]);
@@ -484,6 +544,8 @@ public final class Mat4Math {
      * @param r row for cofactor calculation
      * @param c column for cofactor calculation
      * @return cofactor value from given positions in given matrix 4x4
+     *
+     * @since 1.0.0
      */
     public static float cofactor(final Matrix4 m, final Matrix4Row r, final Matrix4Col c) {
         final int coefficient = (r.ordinal() + c.ordinal()) % 2 == 0 ? 1 : -1;
@@ -498,6 +560,8 @@ public final class Mat4Math {
      * @param r index of row for cofactor calculation
      * @param c index of column for cofactor calculation
      * @return cofactor value from given positions in given matrix 4x4
+     *
+     * @since 1.0.0
      */
     public static float cofactor(final Matrix4 m, final int r, final int c) {
         return cofactor(m, ROWS[r], COLS[c]);
@@ -508,6 +572,8 @@ public final class Mat4Math {
      * 
      * @param m matrix 4x4 for matrix of cofactors construction
      * @return matrix 4x4 of cofactors
+     *
+     * @since 1.0.0
      */
     public static Matrix4 cofactorMatrix(final Matrix4 m) {
         final Matrix4 result = new Mat4();
@@ -529,6 +595,8 @@ public final class Mat4Math {
      * @param eps tolerance
      * @return {@code true} if all elements of matrices 4x4 are equal within
      *         {@code epsilon} tolerance, and {@code false} otherwise
+     *
+     * @since 1.0.0
      */
     public static boolean equalsEpsilon(final Matrix4 m1, final Matrix4 m2, final float eps) {
         for (final Matrix4Row r : ROWS) {
@@ -549,6 +617,8 @@ public final class Mat4Math {
      * @param m2 second matrix 4x4 for comparison
      * @return {@code true} if all elements of matrices 4x4 are approximately equal,
      *         and {@code false} otherwise
+     *
+     * @since 1.0.0
      */
     public static boolean equals(final Matrix4 m1, final Matrix4 m2) {
         return equalsEpsilon(m1, m2, Validator.EPS);
@@ -560,6 +630,8 @@ public final class Mat4Math {
      * @param m matrix 4x4 for analysis
      * @return {@code true} if matrix elements are approximately equal 0, and
      *         {@code false} otherwise
+     *
+     * @since 1.0.0
      */
     public static boolean isZeroed(final Matrix4 m) {
         for (final Matrix4Row r : ROWS) {
@@ -579,6 +651,8 @@ public final class Mat4Math {
      * @param m matrix for analysis
      * @return {@code true} if matrix is square diagonal, and {@code false}
      *         otherwise
+     *
+     * @since 1.0.0
      */
     public static boolean diagonal(final Matrix4 m) {
         for (final Matrix4Row r : ROWS) {
@@ -599,6 +673,8 @@ public final class Mat4Math {
      * Constructs matrix 4x4 of with all 0 elements.
      * 
      * @return matrix 4x4 with all 0 elements
+     *
+     * @since 1.0.0
      */
     public static Matrix4 zeroMat() {
         return new Mat4();
@@ -608,6 +684,8 @@ public final class Mat4Math {
      * Constructs square matrix 4x4 with 1 on main diagonal.
      * 
      * @return square matrix 4x4 with 1 on main diagonal
+     *
+     * @since 1.0.0
      */
     public static Matrix4 unitMat() {
         final Matrix4 result = new Mat4();

--- a/lib/src/main/java/io/github/alphameo/linear_algebra/mat/MatMath.java
+++ b/lib/src/main/java/io/github/alphameo/linear_algebra/mat/MatMath.java
@@ -6,11 +6,15 @@ import io.github.alphameo.linear_algebra.vec.Vector;
 
 /**
  * Class with static functions for arbitrary matrices.
+ *
+ * @since 1.0.0
  */
 public final class MatMath {
 
     /**
      * Default empty constructor
+     *
+     * @since 1.0.0
      */
     public MatMath() {
     }
@@ -20,6 +24,8 @@ public final class MatMath {
      *
      * @param m square matrix for transpose
      * @return given square matrix, which is transposed
+     *
+     * @since 1.0.0
      */
     public static Matrix transposeSquare(final Matrix m) {
         if (!square(m)) {
@@ -43,6 +49,8 @@ public final class MatMath {
      *
      * @param m square matrix for transpose
      * @return new matrix, which is result of transposing of given square matrix
+     *
+     * @since 1.0.0
      */
     public static Matrix transposed(final Matrix m) {
         Matrix result = new Mat(m.width(), m.height());
@@ -63,6 +71,8 @@ public final class MatMath {
      * @param r2 second index of row for swapping
      * @return given matrix with swapped rows
      * @throws ArrayIndexOutOfBoundsException if any row index is out of bounds
+     *
+     * @since 1.0.0
      */
     public static Matrix swapRows(final Matrix m, final int r1, final int r2) throws ArrayIndexOutOfBoundsException {
         float tmp;
@@ -83,6 +93,8 @@ public final class MatMath {
      * @param r2 second index of row for swapping
      * @return new matrix with swapped rows of given matrix
      * @throws ArrayIndexOutOfBoundsException if any row index is out of bounds
+     *
+     * @since 1.0.0
      */
     public static Matrix swappedRows(final Matrix m, final int r1, final int r2) throws ArrayIndexOutOfBoundsException {
         return swapRows(new Mat(m), r1, r2);
@@ -96,6 +108,8 @@ public final class MatMath {
      * @param c2 second index of column for swapping
      * @return given matrix with swapped columns
      * @throws ArrayIndexOutOfBoundsException if any column index is out of bounds
+     *
+     * @since 1.0.0
      */
     public static Matrix swapCols(final Matrix m, final int c1, final int c2) throws ArrayIndexOutOfBoundsException {
         float tmp;
@@ -116,6 +130,8 @@ public final class MatMath {
      * @param c2 second index of column for swapping
      * @return new matrix with swapped columns of given matrix
      * @throws ArrayIndexOutOfBoundsException if any column index is out of bounds
+     *
+     * @since 1.0.0
      */
     public static Matrix swappedCols(final Matrix m, final int c1, final int c2) throws ArrayIndexOutOfBoundsException {
         return swapCols(new Mat(m), c1, c2);
@@ -127,6 +143,8 @@ public final class MatMath {
      * @param m          matrix for multiplication
      * @param multiplier scalar value
      * @return given matrix with multiplied elements
+     *
+     * @since 1.0.0
      */
     public static Matrix mult(final Matrix m, final float multiplier) {
         for (int r = 0; r < m.height(); r++) {
@@ -144,6 +162,8 @@ public final class MatMath {
      * @param m          matrix for multiplication
      * @param multiplier scalar value
      * @return new matrix with multiplied elements of given matrix
+     *
+     * @since 1.0.0
      */
     public static Matrix multiplied(final Matrix m, final float multiplier) {
         return mult(new Mat(m), multiplier);
@@ -156,6 +176,8 @@ public final class MatMath {
      * @param divisor scalar value
      * @return given matrix with divided elements
      * @throws ArithmeticException if {@code divisor} approximately equals 0
+     *
+     * @since 1.0.0
      */
     public static Matrix divide(final Matrix m, final float divisor) throws ArithmeticException {
         Validator.validateDivisor(divisor);
@@ -175,6 +197,8 @@ public final class MatMath {
      * @param divisor scalar value
      * @return new matrix with divided elements of given matrix
      * @throws ArithmeticException if {@code divisor} approximately equals 0
+     *
+     * @since 1.0.0
      */
     public static Matrix divided(final Matrix m, final float divisor) throws ArithmeticException {
         return mult(new Mat(m), divisor);
@@ -188,6 +212,8 @@ public final class MatMath {
      * @param addendum matrix to add
      * @return {@code target} matrix increased by {@code addendum} matrix
      * @throws IllegalArgumentException if matrices have different sizes
+     *
+     * @since 1.0.0
      */
     public static Matrix add(final Matrix target, final Matrix addendum) {
         Validator.validateMatrixSizes(target, addendum, "Addition denied");
@@ -209,6 +235,8 @@ public final class MatMath {
      * @return new matrix with sum of elements of {@code target} matrix and
      *         {@code addendum} matrix
      * @throws IllegalArgumentException if matrices have different sizes
+     *
+     * @since 1.0.0
      */
     public static Matrix added(final Matrix target, final Matrix addendum) {
         return add(new Mat(target), addendum);
@@ -222,6 +250,8 @@ public final class MatMath {
      * @param subtrahend matrix to subtract
      * @return {@code target} matrix subtracted by {@code addendum} matrix
      * @throws IllegalArgumentException if matrices have different sizes
+     *
+     * @since 1.0.0
      */
     public static Matrix sub(final Matrix target, final Matrix subtrahend) {
         Validator.validateMatrixSizes(target, subtrahend, "Subtraction denied");
@@ -243,6 +273,8 @@ public final class MatMath {
      * @return new matrix with components resulting current matrix subtracted
      *         by {@code subtrahend} matrix
      * @throws IllegalArgumentException if matrices have different sizes
+     *
+     * @since 1.0.0
      */
     public static Matrix subtracted(final Matrix target, final Matrix subtrahend) {
         return sub(new Mat(target), subtrahend);
@@ -256,6 +288,8 @@ public final class MatMath {
      * @return matrix, which represents product of given matrices
      * @throws IllegalArgumentException if the first matrix width is not equal to
      *                                  the second matrix height
+     *
+     * @since 1.0.0
      */
     public static Matrix prod(final Matrix m1, final Matrix m2) {
         if (m1.width() != m2.height()) {
@@ -287,6 +321,8 @@ public final class MatMath {
      * @return vector, which represents product of given matrix and vector
      * @throws IllegalArgumentException if width of the matrix is not equal to the
      *                                  vector size
+     *
+     * @since 1.0.0
      */
     public static Vector prod(final Matrix m, final Vector v) {
         if (m.width() != v.size()) {
@@ -314,6 +350,8 @@ public final class MatMath {
      * 
      * @param m matrix to be triangulated
      * @return given matrix, which is triangulated
+     *
+     * @since 1.0.0
      */
     public static Matrix triangulate(final Matrix m) {
         int countOfSwaps = 0;
@@ -359,6 +397,8 @@ public final class MatMath {
      * 
      * @param m matrix to be triangulated
      * @return new matrix, which is result of triangulating of given matrix
+     *
+     * @since 1.0.0
      */
     public static Matrix triangulated(final Matrix m) {
         return triangulate(new Mat(m));
@@ -384,6 +424,8 @@ public final class MatMath {
      * @param m matrix for determinant calculation
      * @return matrix determinant
      * @throws UnsupportedOperationException if matrix is not square
+     *
+     * @since 1.0.0
      */
     public static float detThroughCofactors(final Matrix m) {
         if (!square(m)) {
@@ -413,6 +455,8 @@ public final class MatMath {
      * @param m matrix for determinant calculation
      * @return matrix determinant
      * @throws UnsupportedOperationException if matrix is not square
+     *
+     * @since 1.0.0
      */
     public static float det(final Matrix m) {
         if (!square(m)) {
@@ -435,6 +479,8 @@ public final class MatMath {
      * @return invertible matrix
      * @throws UnsupportedOperationException if matrix is not square
      * @throws RuntimeException              if matrix determinant equals to 0
+     *
+     * @since 1.0.0
      */
     public static Matrix invertible(final Matrix m) {
         if (!square(m)) {
@@ -464,6 +510,8 @@ public final class MatMath {
      * @param c column index to exclude
      * @return minor matrix excluding given row and column
      * @throws UnsupportedOperationException if matrix is not square
+     *
+     * @since 1.0.0
      */
     public static Matrix minorMatrix(final Matrix m, final int r, final int c) {
         if (!square(m)) {
@@ -500,6 +548,8 @@ public final class MatMath {
      * @param c index of column for cofactor calculation
      * @return cofactor value from given positions in given matrix
      * @throws UnsupportedOperationException if matrix is not square
+     *
+     * @since 1.0.0
      */
     public static float cofactor(final Matrix m, final int r, final int c) {
         if (!square(m)) {
@@ -516,6 +566,8 @@ public final class MatMath {
      * @param m matrix for matrix of cofactors construction
      * @return matrix of cofactors
      * @throws UnsupportedOperationException if matrix is not square
+     *
+     * @since 1.0.0
      */
     public static Matrix cofactorMatrix(final Matrix m) {
         if (!square(m)) {
@@ -537,6 +589,8 @@ public final class MatMath {
      * 
      * @param m matrix for analysis
      * @return {@code true} if matrix is square, and {@code false} otherwise
+     *
+     * @since 1.0.0
      */
     public static boolean square(final Matrix m) {
         return m.width() == m.height();
@@ -548,6 +602,8 @@ public final class MatMath {
      * @param m matrix for analysis
      * @return {@code true} if matrix elements are approximately equal 0, and
      *         {@code false} otherwise
+     *
+     * @since 1.0.0
      */
     public static boolean isZeroed(final Matrix m) {
         for (int i = 0; i < m.height(); i++) {
@@ -567,6 +623,8 @@ public final class MatMath {
      * @param m matrix for analysis
      * @return {@code true} if matrix is square diagonal, and {@code false}
      *         otherwise
+     *
+     * @since 1.0.0
      */
     public static boolean diagonal(final Matrix m) {
         if (!square(m)) {
@@ -597,6 +655,8 @@ public final class MatMath {
      * @return {@code true} if all elements of matrices are equal within
      *         {@code epsilon} tolerance, and {@code false} otherwise
      * @throws IllegalArgumentException if matrices have different sizes
+     *
+     * @since 1.0.0
      */
     public static boolean equalsEpsilon(final Matrix m1, final Matrix m2, final float eps) {
         Validator.validateMatrixSizes(m1, m2, "Equalizationt denied");
@@ -619,6 +679,8 @@ public final class MatMath {
      * @return {@code true} if all elements of matrices are approximately equal, and
      *         {@code false} otherwise
      * @throws IllegalArgumentException if matrices have different sizes
+     *
+     * @since 1.0.0
      */
     public static boolean equals(final Matrix m1, final Matrix m2) {
         return equalsEpsilon(m1, m2, Validator.EPS);
@@ -630,6 +692,8 @@ public final class MatMath {
      * @param height height of matrix to be constructed
      * @param width  width of matrix to be constructed
      * @return matrix {@code height} x {@code width} with all 0 elements
+     *
+     * @since 1.0.0
      */
     public static Matrix zeroMat(final int height, final int width) {
         return new Mat(height, width);
@@ -640,6 +704,8 @@ public final class MatMath {
      * 
      * @param size height and width of matrix to be constructed
      * @return square matrix {@code size} x {@code size} with 1 on main diagonal
+     *
+     * @since 1.0.0
      */
     public static Matrix unitMat(final int size) {
         final Matrix result = new Mat(size);

--- a/lib/src/main/java/io/github/alphameo/linear_algebra/mat/MatStringer.java
+++ b/lib/src/main/java/io/github/alphameo/linear_algebra/mat/MatStringer.java
@@ -2,6 +2,8 @@ package io.github.alphameo.linear_algebra.mat;
 
 /**
  * MatUtils
+ *
+ * @since 1.0.0
  */
 class MatStringer {
 

--- a/lib/src/main/java/io/github/alphameo/linear_algebra/mat/Matrix.java
+++ b/lib/src/main/java/io/github/alphameo/linear_algebra/mat/Matrix.java
@@ -2,6 +2,8 @@ package io.github.alphameo.linear_algebra.mat;
 
 /**
  * Interface for arbitrary matrix.
+ *
+ * @since 1.0.0
  */
 public interface Matrix {
 
@@ -11,6 +13,8 @@ public interface Matrix {
      * @param r row index of element
      * @param c column index of element
      * @return element at given position
+     *
+     * @since 1.0.0
      */
     float get(int r, int c);
 
@@ -20,6 +24,8 @@ public interface Matrix {
      * @param r     row index for putting value
      * @param c     column index for putting value
      * @param value component value to be put
+     *
+     * @since 1.0.0
      */
     void set(int r, int c, float value);
 
@@ -27,6 +33,8 @@ public interface Matrix {
      * Returns width (column count) of matrix.
      * 
      * @return width of matrix
+     *
+     * @since 1.0.0
      */
     int width();
 
@@ -34,6 +42,8 @@ public interface Matrix {
      * Returns height (row count) of matrix.
      * 
      * @return height of matrix
+     *
+     * @since 1.0.0
      */
     int height();
 }

--- a/lib/src/main/java/io/github/alphameo/linear_algebra/mat/Matrix3.java
+++ b/lib/src/main/java/io/github/alphameo/linear_algebra/mat/Matrix3.java
@@ -2,6 +2,8 @@ package io.github.alphameo.linear_algebra.mat;
 
 /**
  * Interface for matrix 3x3.
+ *
+ * @since 1.0.0
  */
 public interface Matrix3 extends Matrix {
 
@@ -11,6 +13,8 @@ public interface Matrix3 extends Matrix {
      * @param r row of element
      * @param c column of element
      * @return element at given position
+     *
+     * @since 1.0.0
      */
     float get(Matrix3Row r, Matrix3Col c);
 
@@ -20,6 +24,8 @@ public interface Matrix3 extends Matrix {
      * @param r     row for putting value
      * @param c     column for putting value
      * @param value component value to be put
+     *
+     * @since 1.0.0
      */
     void set(Matrix3Row r, Matrix3Col c, float value);
 }

--- a/lib/src/main/java/io/github/alphameo/linear_algebra/mat/Matrix3Col.java
+++ b/lib/src/main/java/io/github/alphameo/linear_algebra/mat/Matrix3Col.java
@@ -2,18 +2,26 @@ package io.github.alphameo.linear_algebra.mat;
 
 /**
  * Enum of matrix 3x3 columns for safe access.
+ *
+ * @since 1.0.0
  */
 public enum Matrix3Col {
     /**
      * Column index 0
+     *
+     * @since 1.0.0
      */
     C0,
     /**
      * Column index 1
+     *
+     * @since 1.0.0
      */
     C1,
     /**
      * Column index 2
+     *
+     * @since 1.0.0
      */
     C2;
 }

--- a/lib/src/main/java/io/github/alphameo/linear_algebra/mat/Matrix3Row.java
+++ b/lib/src/main/java/io/github/alphameo/linear_algebra/mat/Matrix3Row.java
@@ -2,18 +2,26 @@ package io.github.alphameo.linear_algebra.mat;
 
 /**
  * Enum of matrix 3x3 rows for safe access.
+ *
+ * @since 1.0.0
  */
 public enum Matrix3Row {
     /**
      * Row index 0
+     *
+     * @since 1.0.0
      */
     R0,
     /**
      * Row index 1
+     *
+     * @since 1.0.0
      */
     R1,
     /**
      * Row index 2
+     *
+     * @since 1.0.0
      */
     R2;
 }

--- a/lib/src/main/java/io/github/alphameo/linear_algebra/mat/Matrix4.java
+++ b/lib/src/main/java/io/github/alphameo/linear_algebra/mat/Matrix4.java
@@ -2,6 +2,8 @@ package io.github.alphameo.linear_algebra.mat;
 
 /**
  * Interface for matrix 4x4.
+ *
+ * @since 1.0.0
  */
 public interface Matrix4 extends Matrix {
 
@@ -11,6 +13,8 @@ public interface Matrix4 extends Matrix {
      * @param r row of element
      * @param c column of element
      * @return element at given position
+     *
+     * @since 1.0.0
      */
     float get(Matrix4Row r, Matrix4Col c);
 
@@ -20,6 +24,8 @@ public interface Matrix4 extends Matrix {
      * @param r     row for putting value
      * @param c     column for putting value
      * @param value component value to be put
+     *
+     * @since 1.0.0
      */
     void set(Matrix4Row r, Matrix4Col c, float value);
 }

--- a/lib/src/main/java/io/github/alphameo/linear_algebra/mat/Matrix4Col.java
+++ b/lib/src/main/java/io/github/alphameo/linear_algebra/mat/Matrix4Col.java
@@ -2,22 +2,32 @@ package io.github.alphameo.linear_algebra.mat;
 
 /**
  * Enum of matrix 4x4 columns for safe access.
+ *
+ * @since 1.0.0
  */
 public enum Matrix4Col {
     /**
      * Column index 0
+     *
+     * @since 1.0.0
      */
     C0,
     /**
      * Column index 1
+     *
+     * @since 1.0.0
      */
     C1,
     /**
      * Column index 2
+     *
+     * @since 1.0.0
      */
     C2,
     /**
      * Column index 3
+     *
+     * @since 1.0.0
      */
     C3;
 }

--- a/lib/src/main/java/io/github/alphameo/linear_algebra/mat/Matrix4Row.java
+++ b/lib/src/main/java/io/github/alphameo/linear_algebra/mat/Matrix4Row.java
@@ -2,22 +2,32 @@ package io.github.alphameo.linear_algebra.mat;
 
 /**
  * Enum of matrix 4x4 rows for safe access.
+ *
+ * @since 1.0.0
  */
 public enum Matrix4Row {
     /**
      * Row index 0
+     *
+     * @since 1.0.0
      */
     R0,
     /**
      * Row index 1
+     *
+     * @since 1.0.0
      */
     R1,
     /**
      * Row index 2
+     *
+     * @since 1.0.0
      */
     R2,
     /**
      * Row index 3
+     *
+     * @since 1.0.0
      */
     R3;
 }

--- a/lib/src/main/java/io/github/alphameo/linear_algebra/mat/package-info.java
+++ b/lib/src/main/java/io/github/alphameo/linear_algebra/mat/package-info.java
@@ -1,4 +1,6 @@
 /**
  * Package for Matrix math.
+ *
+ * @since 1.0.0
  */
 package io.github.alphameo.linear_algebra.mat;

--- a/lib/src/main/java/io/github/alphameo/linear_algebra/vec/Vec.java
+++ b/lib/src/main/java/io/github/alphameo/linear_algebra/vec/Vec.java
@@ -7,6 +7,8 @@ import io.github.alphameo.linear_algebra.Equatable;
 
 /**
  * Default implementation of arbitrary vector ({@code Vector interface}).
+ *
+ * @since 1.0.0
  */
 public class Vec implements Vector, Equatable<Vector>, Copyable<Vec> {
 
@@ -16,6 +18,8 @@ public class Vec implements Vector, Equatable<Vector>, Copyable<Vec> {
      * Constructs new vector of given size with all 0.
      * 
      * @param size size of vector for construction
+     *
+     * @since 1.0.0
      */
     public Vec(final int size) {
         this.entries = new float[size];
@@ -25,6 +29,8 @@ public class Vec implements Vector, Equatable<Vector>, Copyable<Vec> {
      * Constructs new vector using values from {@code entries}.
      * 
      * @param entries values for vector components
+     *
+     * @since 1.0.0
      */
     public Vec(final float... entries) {
         this(entries.length);
@@ -37,6 +43,8 @@ public class Vec implements Vector, Equatable<Vector>, Copyable<Vec> {
      * Copies given vector values into new vector.
      * 
      * @param v vector for copying
+     *
+     * @since 1.0.0
      */
     public Vec(final Vector v) {
         this(v.size());
@@ -66,6 +74,8 @@ public class Vec implements Vector, Equatable<Vector>, Copyable<Vec> {
      * You can use it if you need fast comparison.
      * 
      * @return square length of vector
+     *
+     * @since 1.0.0
      */
     public float len2() {
         return VecMath.len2(this);
@@ -75,6 +85,8 @@ public class Vec implements Vector, Equatable<Vector>, Copyable<Vec> {
      * Calculates length of vector.
      * 
      * @return length of vector
+     *
+     * @since 1.0.0
      */
     public float len() {
         return VecMath.len(this);
@@ -85,6 +97,8 @@ public class Vec implements Vector, Equatable<Vector>, Copyable<Vec> {
      *
      * @param multiplier scalar value
      * @return current vector with multiplied components
+     *
+     * @since 1.0.0
      */
     public Vector mult(final float multiplier) {
         return VecMath.mult(this, multiplier);
@@ -96,6 +110,8 @@ public class Vec implements Vector, Equatable<Vector>, Copyable<Vec> {
      *
      * @param multiplier scalar value
      * @return new vector with multiplied components of current vector
+     *
+     * @since 1.0.0
      */
     public Vector multiplied(final float multiplier) {
         return VecMath.multiplied(this, multiplier);
@@ -107,6 +123,8 @@ public class Vec implements Vector, Equatable<Vector>, Copyable<Vec> {
      * @param divisor scalar value
      * @return current vector with divided components
      * @throws ArithmeticException if {@code divisor} approximately equal to 0
+     *
+     * @since 1.0.0
      */
     public Vector divide(final float divisor) throws ArithmeticException {
         return VecMath.divide(this, divisor);
@@ -118,6 +136,8 @@ public class Vec implements Vector, Equatable<Vector>, Copyable<Vec> {
      * @param divisor scalar value
      * @return new vector with divided components of current vector
      * @throws ArithmeticException if {@code divisor} approximately equal to 0
+     *
+     * @since 1.0.0
      */
     public Vector divided(final float divisor) throws ArithmeticException {
         return VecMath.divided(this, divisor);
@@ -128,6 +148,8 @@ public class Vec implements Vector, Equatable<Vector>, Copyable<Vec> {
      * 
      * @return current vector with normalized components
      * @throws ArithmeticException if length of vector equals 0
+     *
+     * @since 1.0.0
      */
     public Vector normalize() throws ArithmeticException {
         return VecMath.normalize(this);
@@ -138,6 +160,8 @@ public class Vec implements Vector, Equatable<Vector>, Copyable<Vec> {
      * 
      * @return current vector with normalized components of given vector
      * @throws ArithmeticException if length of vector equals 0
+     *
+     * @since 1.0.0
      */
     public Vector normalized() throws ArithmeticException {
         return VecMath.normalized(new Vec(this));
@@ -149,6 +173,8 @@ public class Vec implements Vector, Equatable<Vector>, Copyable<Vec> {
      * @param addendum vector to add
      * @return current vector increased by {@code addendum} vector
      * @throws IllegalArgumentException if vectors have different sizes
+     *
+     * @since 1.0.0
      */
     public Vector add(final Vector addendum) {
         return VecMath.add(this, addendum);
@@ -162,6 +188,8 @@ public class Vec implements Vector, Equatable<Vector>, Copyable<Vec> {
      * @return new vector with sum of components of current vector and
      *         {@code addendum} vector
      * @throws IllegalArgumentException if vectors have different sizes
+     *
+     * @since 1.0.0
      */
     public Vector added(final Vector addendum) {
         return VecMath.added(this, addendum);
@@ -174,6 +202,8 @@ public class Vec implements Vector, Equatable<Vector>, Copyable<Vec> {
      * @param subtrahend vector to subtract
      * @return current vector subtracted by {@code subtrahend} vector
      * @throws IllegalArgumentException if vectors have different sizes
+     *
+     * @since 1.0.0
      */
     public Vector sub(final Vector subtrahend) {
         return VecMath.sub(this, subtrahend);
@@ -187,6 +217,8 @@ public class Vec implements Vector, Equatable<Vector>, Copyable<Vec> {
      * @return new vector with components resulting current vector subtracted
      *         by {@code subtrahend} vector
      * @throws IllegalArgumentException if vectors have different sizes
+     *
+     * @since 1.0.0
      */
     public Vector subtracted(final Vector subtrahend) {
         return VecMath.subtracted(this, subtrahend);
@@ -197,6 +229,8 @@ public class Vec implements Vector, Equatable<Vector>, Copyable<Vec> {
      *
      * @param v second vector
      * @return dot (scalar) product of vectors
+     *
+     * @since 1.0.0
      */
     public float dot(final Vector v) {
         return VecMath.dot(this, v);
@@ -208,6 +242,8 @@ public class Vec implements Vector, Equatable<Vector>, Copyable<Vec> {
      * @param v second vector
      * @return vector, which represents cross (vector) product of vectors
      * @throws IllegalArgumentException if vectors' sizes are not equal 3
+     *
+     * @since 1.0.0
      */
     public Vector cross(final Vector v) {
         return VecMath.cross(this, v);
@@ -260,6 +296,8 @@ public class Vec implements Vector, Equatable<Vector>, Copyable<Vec> {
      * 
      * @param size size of vector to be constructed
      * @return new zero vector of given {@code size}
+     *
+     * @since 1.0.0
      */
     public static Vector zeroVec(final int size) {
         return VecMath.zeroVec(size);
@@ -270,6 +308,8 @@ public class Vec implements Vector, Equatable<Vector>, Copyable<Vec> {
      * 
      * @param size size of vector to be constructed
      * @return new unit vector of given {@code size}
+     *
+     * @since 1.0.0
      */
     public static Vector unitVec(final int size) {
         return VecMath.unitVec(size);

--- a/lib/src/main/java/io/github/alphameo/linear_algebra/vec/Vec2.java
+++ b/lib/src/main/java/io/github/alphameo/linear_algebra/vec/Vec2.java
@@ -7,6 +7,8 @@ import io.github.alphameo.linear_algebra.Equatable;
 
 /**
  * Default implementation of vector with size 2 ({@code Vector2 interface}).
+ *
+ * @since 1.0.0
  */
 public class Vec2 implements Vector2, Equatable<Vector2>, Copyable<Vec2> {
 
@@ -14,6 +16,8 @@ public class Vec2 implements Vector2, Equatable<Vector2>, Copyable<Vec2> {
 
     /**
      * Constructs new vector of size 2 with all 0.
+     *
+     * @since 1.0.0
      */
     public Vec2() {
         entries = new float[2];
@@ -24,6 +28,8 @@ public class Vec2 implements Vector2, Equatable<Vector2>, Copyable<Vec2> {
      * 
      * @param x first component of vector
      * @param y second component of vector
+     *
+     * @since 1.0.0
      */
     public Vec2(final float x, final float y) {
         this();
@@ -35,6 +41,8 @@ public class Vec2 implements Vector2, Equatable<Vector2>, Copyable<Vec2> {
      * Copies given vector of size 2 values into new vector of size 2.
      * 
      * @param v vector of size 2 for copying
+     *
+     * @since 1.0.0
      */
     public Vec2(final Vector2 v) {
         this(v.x(), v.y());
@@ -89,6 +97,8 @@ public class Vec2 implements Vector2, Equatable<Vector2>, Copyable<Vec2> {
      * You can use it if you need fast comparison.
      * 
      * @return square length of vector
+     *
+     * @since 1.0.0
      */
     public float len2() {
         return Vec2Math.len2(this);
@@ -98,6 +108,8 @@ public class Vec2 implements Vector2, Equatable<Vector2>, Copyable<Vec2> {
      * Calculates length of vector.
      * 
      * @return length of vector
+     *
+     * @since 1.0.0
      */
     public float len() {
         return Vec2Math.len(this);
@@ -108,6 +120,8 @@ public class Vec2 implements Vector2, Equatable<Vector2>, Copyable<Vec2> {
      *
      * @param multiplier scalar value
      * @return current vector with multiplied components
+     *
+     * @since 1.0.0
      */
     public Vector2 mult(final float multiplier) {
         return Vec2Math.mult(this, multiplier);
@@ -119,6 +133,8 @@ public class Vec2 implements Vector2, Equatable<Vector2>, Copyable<Vec2> {
      *
      * @param multiplier scalar value
      * @return new vector with multiplied components of current vector
+     *
+     * @since 1.0.0
      */
     public Vector2 multiplied(final float multiplier) {
         return Vec2Math.multiplied(this, multiplier);
@@ -130,6 +146,8 @@ public class Vec2 implements Vector2, Equatable<Vector2>, Copyable<Vec2> {
      * @param divisor scalar value
      * @return current vector with divided components
      * @throws ArithmeticException if {@code divisor} approximately equal to 0
+     *
+     * @since 1.0.0
      */
     public Vector2 divide(final float divisor) throws ArithmeticException {
         return Vec2Math.divide(this, divisor);
@@ -141,6 +159,8 @@ public class Vec2 implements Vector2, Equatable<Vector2>, Copyable<Vec2> {
      * @param divisor scalar value
      * @return new vector with divided components of current vector
      * @throws ArithmeticException if {@code divisor} approximately equal to 0
+     *
+     * @since 1.0.0
      */
     public Vector2 divided(final float divisor) throws ArithmeticException {
         return Vec2Math.divided(this, divisor);
@@ -151,6 +171,8 @@ public class Vec2 implements Vector2, Equatable<Vector2>, Copyable<Vec2> {
      * 
      * @return current vector with normalized components
      * @throws ArithmeticException if length of vector equals 0
+     *
+     * @since 1.0.0
      */
     public Vector2 normalize() throws ArithmeticException {
         return Vec2Math.normalize(this);
@@ -161,6 +183,8 @@ public class Vec2 implements Vector2, Equatable<Vector2>, Copyable<Vec2> {
      * 
      * @return current vector with normalized components of given vector
      * @throws ArithmeticException if length of vector equals 0
+     *
+     * @since 1.0.0
      */
     public Vector2 normalized() throws ArithmeticException {
         return Vec2Math.normalized(new Vec2(this));
@@ -171,6 +195,8 @@ public class Vec2 implements Vector2, Equatable<Vector2>, Copyable<Vec2> {
      *
      * @param addendum vector to add
      * @return current vector increased by {@code addendum} vector
+     *
+     * @since 1.0.0
      */
     public Vector2 add(final Vector2 addendum) {
         return Vec2Math.add(this, addendum);
@@ -183,6 +209,8 @@ public class Vec2 implements Vector2, Equatable<Vector2>, Copyable<Vec2> {
      * @param addendum vector to add
      * @return new vector with sum of components of current vector and
      *         {@code addendum} vector
+     *
+     * @since 1.0.0
      */
     public Vector2 added(final Vector2 addendum) {
         return Vec2Math.added(this, addendum);
@@ -194,6 +222,8 @@ public class Vec2 implements Vector2, Equatable<Vector2>, Copyable<Vec2> {
      * 
      * @param subtrahend vector to subtract
      * @return current vector subtracted by {@code subtrahend} vector
+     *
+     * @since 1.0.0
      */
     public Vector2 sub(final Vector2 subtrahend) {
         return Vec2Math.sub(this, subtrahend);
@@ -206,6 +236,8 @@ public class Vec2 implements Vector2, Equatable<Vector2>, Copyable<Vec2> {
      * @param subtrahend vector to subtract
      * @return new vector with components resulting current vector subtracted
      *         by {@code subtrahend} vector
+     *
+     * @since 1.0.0
      */
     public Vector2 subtracted(final Vector2 subtrahend) {
         return Vec2Math.subtracted(this, subtrahend);
@@ -216,6 +248,8 @@ public class Vec2 implements Vector2, Equatable<Vector2>, Copyable<Vec2> {
      *
      * @param v second vector
      * @return dot (scalar) product of vectors
+     *
+     * @since 1.0.0
      */
     public float dot(final Vector2 v) {
         return Vec2Math.dot(this, v);
@@ -228,6 +262,8 @@ public class Vec2 implements Vector2, Equatable<Vector2>, Copyable<Vec2> {
      *
      * @return new vector of size 3 including components of current vector and 1 as
      *         last component
+     *
+     * @since 1.0.0
      */
     public Vector3 toVec3() {
         return Vec2Math.toVec3(this);
@@ -279,6 +315,8 @@ public class Vec2 implements Vector2, Equatable<Vector2>, Copyable<Vec2> {
      * Constructs new vector of size 2 with all 0 components.
      * 
      * @return new zero vector of size 2
+     *
+     * @since 1.0.0
      */
     public static Vector2 zeroVec() {
         return Vec2Math.zeroVec();
@@ -288,6 +326,8 @@ public class Vec2 implements Vector2, Equatable<Vector2>, Copyable<Vec2> {
      * Constructs new vector of size 2 with all 1 components.
      * 
      * @return new unit vector of size 2
+     *
+     * @since 1.0.0
      */
     public static Vector2 unitVec() {
         return Vec2Math.unitVec();

--- a/lib/src/main/java/io/github/alphameo/linear_algebra/vec/Vec2Math.java
+++ b/lib/src/main/java/io/github/alphameo/linear_algebra/vec/Vec2Math.java
@@ -4,11 +4,15 @@ import io.github.alphameo.linear_algebra.Validator;
 
 /**
  * Class with static functions for arbitrary vectors.
+ *
+ * @since 1.0.0
  */
 public final class Vec2Math {
 
     /**
      * Default empty constructor
+     *
+     * @since 1.0.0
      */
     public Vec2Math() {
     }
@@ -20,6 +24,8 @@ public final class Vec2Math {
      * 
      * @param v vector of size 2 for square length calculation
      * @return square length of given vector
+     *
+     * @since 1.0.0
      */
     public static float len2(final Vector2 v) {
         return v.x() * v.x() + v.y() * v.y();
@@ -30,6 +36,8 @@ public final class Vec2Math {
      * 
      * @param v vector of size 2 for length calculation
      * @return length of given vector
+     *
+     * @since 1.0.0
      */
     public static float len(final Vector2 v) {
         return (float) Math.sqrt(len2(v));
@@ -41,6 +49,8 @@ public final class Vec2Math {
      * @param v          vector of size 2 for multiplication
      * @param multiplier scalar value
      * @return given vector with multiplied components
+     *
+     * @since 1.0.0
      */
     public static Vector2 mult(final Vector2 v, final float multiplier) {
         v.setX(v.x() * multiplier);
@@ -56,6 +66,8 @@ public final class Vec2Math {
      * @param v          vector of size 2 for multiplication
      * @param multiplier scalar value
      * @return new vector of size 2 with multiplied components of given vector
+     *
+     * @since 1.0.0
      */
     public static Vector2 multiplied(final Vector2 v, final float multiplier) {
         return mult(new Vec2(v), multiplier);
@@ -68,6 +80,8 @@ public final class Vec2Math {
      * @param divisor scalar value
      * @return given vector with divided components
      * @throws ArithmeticException if {@code divisor} approximately equal to 0
+     *
+     * @since 1.0.0
      */
     public static Vector2 divide(final Vector2 v, final float divisor) throws ArithmeticException {
         Validator.validateDivisor(divisor);
@@ -85,6 +99,8 @@ public final class Vec2Math {
      * @param divisor scalar value
      * @return new vector of size 2 with divided components of given vector
      * @throws ArithmeticException if {@code divisor} approximately equal to 0
+     *
+     * @since 1.0.0
      */
     public static Vector2 divided(final Vector2 v, final float divisor) throws ArithmeticException {
         return divide(new Vec2(v), divisor);
@@ -96,6 +112,8 @@ public final class Vec2Math {
      * @param v vector of size 2 to be normalized
      * @return given vector with normalized components
      * @throws ArithmeticException if length of given vector equals 0
+     *
+     * @since 1.0.0
      */
     public static Vector2 normalize(final Vector2 v) throws ArithmeticException {
         return divide(v, len(v));
@@ -107,6 +125,8 @@ public final class Vec2Math {
      * @param v vector of size 2 to be normalized
      * @return new vector of size 2 with normalized components of given vector
      * @throws ArithmeticException if length of given vector equals 0
+     *
+     * @since 1.0.0
      */
     public static Vector2 normalized(final Vector2 v) throws ArithmeticException {
         return divided(v, len(v));
@@ -119,6 +139,8 @@ public final class Vec2Math {
      * @param target   vector of size 2 to be added
      * @param addendum vector of size 2 to add
      * @return {@code target} vector increased by {@code addendum} vector
+     *
+     * @since 1.0.0
      */
     public static Vector2 add(final Vector2 target, final Vector2 addendum) {
         target.setX(target.x() + addendum.x());
@@ -136,6 +158,8 @@ public final class Vec2Math {
      * @return new vector of size 2 with sum of components of {@code target} vector
      *         and
      *         {@code addendum} vector
+     *
+     * @since 1.0.0
      */
     public static Vector2 added(final Vector2 target, final Vector2 addendum) {
         return add(new Vec2(target), addendum);
@@ -148,6 +172,8 @@ public final class Vec2Math {
      * @param target     vector of size 2 to be subtracted
      * @param subtrahend vector of size 2 to subtract
      * @return {@code target} vector subtracted by {@code subtrahend} vector
+     *
+     * @since 1.0.0
      */
     public static Vector2 sub(final Vector2 target, final Vector2 subtrahend) {
         target.setX(target.x() - subtrahend.x());
@@ -164,6 +190,8 @@ public final class Vec2Math {
      * @param subtrahend vector of size 2 to subtract
      * @return new vector of size 2 with components resulting {@code target} vector
      *         subtracted by {@code subtrahend} vector
+     *
+     * @since 1.0.0
      */
     public static Vector2 subtracted(final Vector2 target, final Vector2 subtrahend) {
         return sub(new Vec2(target), subtrahend);
@@ -175,6 +203,8 @@ public final class Vec2Math {
      * @param v1 first vector of size 2
      * @param v2 second vector of size 2
      * @return dot (scalar) product of given vectors
+     *
+     * @since 1.0.0
      */
     public static float dot(final Vector2 v1, final Vector2 v2) {
         return v1.x() * v2.x() + v1.y() * v2.y();
@@ -189,6 +219,8 @@ public final class Vec2Math {
      * @param eps tolerance
      * @return {@code true} if all components of vectors are equal within
      *         {@code epsilon} tolerance, and {@code false} otherwise
+     *
+     * @since 1.0.0
      */
     public static boolean equalsEpsilon(final Vector2 v1, final Vector2 v2, final float eps) {
         return Validator.equalsEpsilon(v1.x(), v2.x(), eps)
@@ -202,6 +234,8 @@ public final class Vec2Math {
      * @param v2 second vector of size 2 for comparison
      * @return {@code true} if all components of vectors are approximately equal,
      *         and {@code false} otherwise
+     *
+     * @since 1.0.0
      */
     public static boolean equals(final Vector2 v1, final Vector2 v2) {
         return equalsEpsilon(v1, v2, Validator.EPS);
@@ -215,6 +249,8 @@ public final class Vec2Math {
      * @param v vector of size 2
      * @return new vector of size 3 including components of given vector and 1 as
      *         last component
+     *
+     * @since 1.0.0
      */
     public static Vector3 toVec3(final Vector2 v) {
         return new Vec3(v.x(), v.y(), 1);
@@ -224,6 +260,8 @@ public final class Vec2Math {
      * Constructs new vector of size 2 with all 0 components.
      * 
      * @return new zero vector of size 2
+     *
+     * @since 1.0.0
      */
     public static Vector2 zeroVec() {
         return new Vec2();
@@ -233,6 +271,8 @@ public final class Vec2Math {
      * Constructs new vector of size 2 with all 1 components.
      * 
      * @return new unit vector of size 2
+     *
+     * @since 1.0.0
      */
     public static Vector2 unitVec() {
         return new Vec2(1, 1);

--- a/lib/src/main/java/io/github/alphameo/linear_algebra/vec/Vec3.java
+++ b/lib/src/main/java/io/github/alphameo/linear_algebra/vec/Vec3.java
@@ -7,6 +7,8 @@ import io.github.alphameo.linear_algebra.Equatable;
 
 /**
  * Default implementation of vector with size 3 ({@code Vector3 interface}).
+ *
+ * @since 1.0.0
  */
 public class Vec3 implements Vector3, Equatable<Vector3>, Copyable<Vec3> {
 
@@ -14,6 +16,8 @@ public class Vec3 implements Vector3, Equatable<Vector3>, Copyable<Vec3> {
 
     /**
      * Constructs new vector of size 3 with all 0.
+     *
+     * @since 1.0.0
      */
     public Vec3() {
         entries = new float[3];
@@ -26,6 +30,8 @@ public class Vec3 implements Vector3, Equatable<Vector3>, Copyable<Vec3> {
      * @param x first component of vector
      * @param y second component of vector
      * @param z third component of vector
+     *
+     * @since 1.0.0
      */
     public Vec3(final float x, final float y, final float z) {
         this();
@@ -38,6 +44,8 @@ public class Vec3 implements Vector3, Equatable<Vector3>, Copyable<Vec3> {
      * Copies given vector of size 3 values into new vector of size 3.
      * 
      * @param v vector of size 3 for copying
+     *
+     * @since 1.0.0
      */
     public Vec3(final Vector3 v) {
         this(v.x(), v.y(), v.z());
@@ -101,6 +109,8 @@ public class Vec3 implements Vector3, Equatable<Vector3>, Copyable<Vec3> {
      * You can use it if you need fast comparison.
      * 
      * @return square length of vector
+     *
+     * @since 1.0.0
      */
     public float len2() {
         return Vec3Math.len2(this);
@@ -110,6 +120,8 @@ public class Vec3 implements Vector3, Equatable<Vector3>, Copyable<Vec3> {
      * Calculates length of vector.
      * 
      * @return length of vector
+     *
+     * @since 1.0.0
      */
     public float len() {
         return Vec3Math.len(this);
@@ -120,6 +132,8 @@ public class Vec3 implements Vector3, Equatable<Vector3>, Copyable<Vec3> {
      *
      * @param multiplier scalar value
      * @return current vector with multiplied components
+     *
+     * @since 1.0.0
      */
     public Vector3 mult(final float multiplier) {
         return Vec3Math.mult(this, multiplier);
@@ -131,6 +145,8 @@ public class Vec3 implements Vector3, Equatable<Vector3>, Copyable<Vec3> {
      *
      * @param multiplier scalar value
      * @return new vector with multiplied components of current vector
+     *
+     * @since 1.0.0
      */
     public Vector3 multiplied(final float multiplier) {
         return Vec3Math.multiplied(this, multiplier);
@@ -142,6 +158,8 @@ public class Vec3 implements Vector3, Equatable<Vector3>, Copyable<Vec3> {
      * @param divisor scalar value
      * @return current vector with divided components
      * @throws ArithmeticException if {@code divisor} approximately equal to 0
+     *
+     * @since 1.0.0
      */
     public Vector3 divide(final float divisor) throws ArithmeticException {
         return Vec3Math.divide(this, divisor);
@@ -153,6 +171,8 @@ public class Vec3 implements Vector3, Equatable<Vector3>, Copyable<Vec3> {
      * @param divisor scalar value
      * @return current vector with divided components
      * @throws ArithmeticException if {@code divisor} approximately equal to 0
+     *
+     * @since 1.0.0
      */
     public Vector3 divided(final float divisor) throws ArithmeticException {
         return Vec3Math.divided(this, divisor);
@@ -163,6 +183,8 @@ public class Vec3 implements Vector3, Equatable<Vector3>, Copyable<Vec3> {
      * 
      * @return current vector with normalized components
      * @throws ArithmeticException if length of vector equals 0
+     *
+     * @since 1.0.0
      */
     public Vector3 normalize() throws ArithmeticException {
         return Vec3Math.normalize(this);
@@ -173,6 +195,8 @@ public class Vec3 implements Vector3, Equatable<Vector3>, Copyable<Vec3> {
      * 
      * @return current vector with normalized components of given vector
      * @throws ArithmeticException if length of vector equals 0
+     *
+     * @since 1.0.0
      */
     public Vector3 normalized() throws ArithmeticException {
         return Vec3Math.normalized(new Vec3(this));
@@ -183,6 +207,8 @@ public class Vec3 implements Vector3, Equatable<Vector3>, Copyable<Vec3> {
      *
      * @param addendum vector to add
      * @return current vector increased by {@code addendum} vector
+     *
+     * @since 1.0.0
      */
     public Vector3 add(final Vector3 addendum) {
         return Vec3Math.add(this, addendum);
@@ -195,6 +221,8 @@ public class Vec3 implements Vector3, Equatable<Vector3>, Copyable<Vec3> {
      * @param addendum vector to add
      * @return new vector with sum of components of current vector and
      *         {@code addendum} vector
+     *
+     * @since 1.0.0
      */
     public Vector3 added(final Vector3 addendum) {
         return Vec3Math.added(this, addendum);
@@ -206,6 +234,8 @@ public class Vec3 implements Vector3, Equatable<Vector3>, Copyable<Vec3> {
      * 
      * @param subtrahend vector to subtract
      * @return current vector subtracted by {@code subtrahend} vector
+     *
+     * @since 1.0.0
      */
     public Vector3 sub(final Vector3 subtrahend) {
         return Vec3Math.sub(this, subtrahend);
@@ -218,6 +248,8 @@ public class Vec3 implements Vector3, Equatable<Vector3>, Copyable<Vec3> {
      * @param subtrahend vector to subtract
      * @return new vector with components resulting current vector subtracted
      *         by {@code subtrahend} vector
+     *
+     * @since 1.0.0
      */
     public Vector3 subtracted(final Vector3 subtrahend) {
         return Vec3Math.subtracted(this, subtrahend);
@@ -228,6 +260,8 @@ public class Vec3 implements Vector3, Equatable<Vector3>, Copyable<Vec3> {
      *
      * @param v second vector
      * @return dot (scalar) product of vectors
+     *
+     * @since 1.0.0
      */
     public float dot(final Vector3 v) {
         return Vec3Math.dot(this, v);
@@ -238,6 +272,8 @@ public class Vec3 implements Vector3, Equatable<Vector3>, Copyable<Vec3> {
      *
      * @param v second vector
      * @return vector, which represents cross (vector) product of vectors
+     *
+     * @since 1.0.0
      */
     public Vector3 cross(final Vector3 v) {
         final Vector3 result = new Vec3();
@@ -253,6 +289,8 @@ public class Vec3 implements Vector3, Equatable<Vector3>, Copyable<Vec3> {
      *
      * @return new vector of size 3 including components of current vector and 1 as
      *         last component
+     *
+     * @since 1.0.0
      */
     public Vector4 toVec4() {
         return Vec3Math.toVec4(this);
@@ -304,6 +342,8 @@ public class Vec3 implements Vector3, Equatable<Vector3>, Copyable<Vec3> {
      * Constructs new vector of size 3 with all 0 components.
      * 
      * @return new zero vector of size 3
+     *
+     * @since 1.0.0
      */
     public static Vector3 zeroVec() {
         return Vec3Math.zeroVec();
@@ -313,6 +353,8 @@ public class Vec3 implements Vector3, Equatable<Vector3>, Copyable<Vec3> {
      * Constructs new vector of size 4 with all 1 components.
      * 
      * @return new unit vector of size 4
+     *
+     * @since 1.0.0
      */
     public static Vector3 unitVec() {
         return Vec3Math.unitVec();

--- a/lib/src/main/java/io/github/alphameo/linear_algebra/vec/Vec3Math.java
+++ b/lib/src/main/java/io/github/alphameo/linear_algebra/vec/Vec3Math.java
@@ -4,11 +4,15 @@ import io.github.alphameo.linear_algebra.Validator;
 
 /**
  * Class with static functions for vectors of size 3.
+ *
+ * @since 1.0.0
  */
 public final class Vec3Math {
 
     /**
      * Default empty constructor
+     *
+     * @since 1.0.0
      */
     public Vec3Math() {
     }
@@ -20,6 +24,8 @@ public final class Vec3Math {
      * 
      * @param v vector of size 3 for square length calculation
      * @return square length of given vector
+     *
+     * @since 1.0.0
      */
     public static float len2(final Vector3 v) {
         return v.x() * v.x() + v.y() * v.y() + v.z() * v.z();
@@ -30,6 +36,8 @@ public final class Vec3Math {
      * 
      * @param v vector of size 3 for length calculation
      * @return length of given vector
+     *
+     * @since 1.0.0
      */
     public static float len(final Vector3 v) {
         return (float) Math.sqrt(len2(v));
@@ -41,6 +49,8 @@ public final class Vec3Math {
      * @param v          vector of size 3 for multiplication
      * @param multiplier scalar value
      * @return given vector with multiplied components
+     *
+     * @since 1.0.0
      */
     public static Vector3 mult(final Vector3 v, final float multiplier) {
         v.setX(v.x() * multiplier);
@@ -57,6 +67,8 @@ public final class Vec3Math {
      * @param v          vector of size 3 for multiplication
      * @param multiplier scalar value
      * @return new vector of size 3 with multiplied components of given vector
+     *
+     * @since 1.0.0
      */
     public static Vector3 multiplied(final Vector3 v, final float multiplier) {
         return mult(new Vec3(v), multiplier);
@@ -69,6 +81,8 @@ public final class Vec3Math {
      * @param divisor scalar value
      * @return given vector with divided components
      * @throws ArithmeticException if {@code divisor} approximately equal to 0
+     *
+     * @since 1.0.0
      */
     public static Vector3 divide(final Vector3 v, final float divisor) throws ArithmeticException {
         Validator.validateDivisor(divisor);
@@ -87,6 +101,8 @@ public final class Vec3Math {
      * @param divisor scalar value
      * @return new vector of size 3 with divided components of given vector
      * @throws ArithmeticException if {@code divisor} approximately equal to 0
+     *
+     * @since 1.0.0
      */
     public static Vector3 divided(final Vector3 v, final float divisor) throws ArithmeticException {
         return divide(new Vec3(v), divisor);
@@ -98,6 +114,8 @@ public final class Vec3Math {
      * @param v vector of size 3 to be normalized
      * @return given vector with normalized components
      * @throws ArithmeticException if length of given vector equals 0
+     *
+     * @since 1.0.0
      */
     public static Vector3 normalize(final Vector3 v) throws ArithmeticException {
         return divide(v, len(v));
@@ -109,6 +127,8 @@ public final class Vec3Math {
      * @param v vector of size 3 to be normalized
      * @return new vector of size 3 with normalized components of given vector
      * @throws IllegalArgumentException if length of given vector equals 0
+     *
+     * @since 1.0.0
      */
     public static Vector3 normalized(final Vector3 v) {
         return divided(v, len(v));
@@ -121,6 +141,8 @@ public final class Vec3Math {
      * @param target   vector of size 3 to be added
      * @param addendum vector of size 3 to add
      * @return {@code target} vector increased by {@code addendum} vector
+     *
+     * @since 1.0.0
      */
     public static Vector3 add(final Vector3 target, final Vector3 addendum) {
         target.setX(target.x() + addendum.x());
@@ -139,6 +161,8 @@ public final class Vec3Math {
      * @return new vector of size 3 with sum of components of {@code target} vector
      *         and
      *         {@code addendum} vector
+     *
+     * @since 1.0.0
      */
     public static Vector3 added(final Vector3 target, final Vector3 addendum) {
         return add(target, addendum);
@@ -151,6 +175,8 @@ public final class Vec3Math {
      * @param target     vector of size 3 to be subtracted
      * @param subtrahend vector of size 3 to subtract
      * @return {@code target} vector subtracted by {@code subtrahend} vector
+     *
+     * @since 1.0.0
      */
     public static Vector3 sub(final Vector3 target, final Vector3 subtrahend) {
         target.setX(target.x() - subtrahend.x());
@@ -168,6 +194,8 @@ public final class Vec3Math {
      * @param subtrahend vector of size 3 to subtract
      * @return new vector of size 3 with components resulting {@code target} vector
      *         subtracted by {@code subtrahend} vector
+     *
+     * @since 1.0.0
      */
     public static Vector3 subtracted(final Vector3 target, final Vector3 subtrahend) {
         return sub(new Vec3(target), subtrahend);
@@ -179,6 +207,8 @@ public final class Vec3Math {
      * @param v1 first vector of size 3
      * @param v2 second vector of size 3
      * @return dot (scalar) product of given vectors
+     *
+     * @since 1.0.0
      */
     public static float dot(final Vector3 v1, final Vector3 v2) {
         return v1.x() * v2.x() + v1.y() * v2.y() + v1.z() * v2.z();
@@ -191,6 +221,8 @@ public final class Vec3Math {
      * @param v2 second vector of size 3
      * @return vector of size 3, which represents cross (vector) product of given
      *         vectors
+     *
+     * @since 1.0.0
      */
     public static Vector3 cross(final Vector3 v1, final Vector3 v2) {
         final float x = v1.y() * v2.z() - v1.z() * v2.y();
@@ -209,6 +241,8 @@ public final class Vec3Math {
      * @param eps tolerance
      * @return {@code true} if all components of vectors are equal within
      *         {@code epsilon} tolerance, and {@code false} otherwise
+     *
+     * @since 1.0.0
      */
     public static boolean equalsEpsilon(final Vector3 v1, final Vector3 v2, final float eps) {
         return Validator.equalsEpsilon(v1.x(), v2.x(), eps)
@@ -223,6 +257,8 @@ public final class Vec3Math {
      * @param v2 second vector of size 3 for comparison
      * @return {@code true} if all components of vectors are approximately equal,
      *         and {@code false} otherwise
+     *
+     * @since 1.0.0
      */
     public static boolean equals(final Vector3 v1, final Vector3 v2) {
         return equalsEpsilon(v1, v2, Validator.EPS);
@@ -236,6 +272,8 @@ public final class Vec3Math {
      * @param v vector of size 3
      * @return new vector of size 4 including components of given vector and 1 as
      *         last component
+     *
+     * @since 1.0.0
      */
     public static Vector4 toVec4(final Vector3 v) {
         return new Vec4(v.x(), v.y(), v.z(), 1);
@@ -245,6 +283,8 @@ public final class Vec3Math {
      * Constructs new vector of size 3 with all 0 components.
      * 
      * @return new zero vector of size 3
+     *
+     * @since 1.0.0
      */
     public static Vector3 zeroVec() {
         return new Vec3();
@@ -254,6 +294,8 @@ public final class Vec3Math {
      * Constructs new vector of size 3 with all 1 components.
      * 
      * @return new unit vector of size 3
+     *
+     * @since 1.0.0
      */
     public static Vector3 unitVec() {
         return new Vec3(1, 1, 1);

--- a/lib/src/main/java/io/github/alphameo/linear_algebra/vec/Vec4.java
+++ b/lib/src/main/java/io/github/alphameo/linear_algebra/vec/Vec4.java
@@ -7,6 +7,8 @@ import io.github.alphameo.linear_algebra.Equatable;
 
 /**
  * Default implementation of vector with size 2 ({@code Vector2 interface}).
+ *
+ * @since 1.0.0
  */
 public class Vec4 implements Vector4, Equatable<Vector4>, Copyable<Vec4> {
 
@@ -14,6 +16,8 @@ public class Vec4 implements Vector4, Equatable<Vector4>, Copyable<Vec4> {
 
     /**
      * Constructs new vector of size 4 with all 0.
+     *
+     * @since 1.0.0
      */
     public Vec4() {
         entries = new float[4];
@@ -27,6 +31,8 @@ public class Vec4 implements Vector4, Equatable<Vector4>, Copyable<Vec4> {
      * @param y second component of vector
      * @param z third component of vector
      * @param w fourth component of vector
+     *
+     * @since 1.0.0
      */
     public Vec4(final float x, final float y, final float z, final float w) {
         this();
@@ -40,6 +46,8 @@ public class Vec4 implements Vector4, Equatable<Vector4>, Copyable<Vec4> {
      * Copies given vector of size 4 values into new vector of size 2.
      * 
      * @param v vector of size 4 for copying
+     *
+     * @since 1.0.0
      */
     public Vec4(final Vector4 v) {
         this(v.x(), v.y(), v.z(), v.w());
@@ -114,6 +122,8 @@ public class Vec4 implements Vector4, Equatable<Vector4>, Copyable<Vec4> {
      * You can use it if you need fast comparison.
      * 
      * @return square length of vector
+     *
+     * @since 1.0.0
      */
     public float len2() {
         return Vec4Math.len2(this);
@@ -123,6 +133,8 @@ public class Vec4 implements Vector4, Equatable<Vector4>, Copyable<Vec4> {
      * Calculates length of vector.
      * 
      * @return length of vector
+     *
+     * @since 1.0.0
      */
     public float len() {
         return Vec4Math.len(this);
@@ -133,6 +145,8 @@ public class Vec4 implements Vector4, Equatable<Vector4>, Copyable<Vec4> {
      *
      * @param multiplier scalar value
      * @return current vector with multiplied components
+     *
+     * @since 1.0.0
      */
     public Vector4 mult(final float multiplier) {
         return Vec4Math.mult(this, multiplier);
@@ -144,6 +158,8 @@ public class Vec4 implements Vector4, Equatable<Vector4>, Copyable<Vec4> {
      *
      * @param multiplier scalar value
      * @return new vector with multiplied components of current vector
+     *
+     * @since 1.0.0
      */
     public Vector4 multiplied(final float multiplier) {
         return Vec4Math.multiplied(this, multiplier);
@@ -155,6 +171,8 @@ public class Vec4 implements Vector4, Equatable<Vector4>, Copyable<Vec4> {
      * @param divisor scalar value
      * @return current vector with divided components
      * @throws ArithmeticException if {@code divisor} approximately equal to 0
+     *
+     * @since 1.0.0
      */
     public Vector4 divide(final float divisor) throws ArithmeticException {
         return Vec4Math.divide(this, divisor);
@@ -166,6 +184,8 @@ public class Vec4 implements Vector4, Equatable<Vector4>, Copyable<Vec4> {
      * @param divisor scalar value
      * @return new vector with divided components of current vector
      * @throws ArithmeticException if {@code divisor} approximately equal to 0
+     *
+     * @since 1.0.0
      */
     public Vector4 divided(final float divisor) throws ArithmeticException {
         return Vec4Math.divided(this, divisor);
@@ -176,6 +196,8 @@ public class Vec4 implements Vector4, Equatable<Vector4>, Copyable<Vec4> {
      * 
      * @return current vector with normalized components
      * @throws ArithmeticException if length of vector equals 0
+     *
+     * @since 1.0.0
      */
     public Vector4 normalize() throws ArithmeticException {
         return Vec4Math.normalize(this);
@@ -186,6 +208,8 @@ public class Vec4 implements Vector4, Equatable<Vector4>, Copyable<Vec4> {
      * 
      * @return current vector with normalized components of given vector
      * @throws ArithmeticException if length of vector equals 0
+     *
+     * @since 1.0.0
      */
     public Vector4 normalized() throws ArithmeticException {
         return Vec4Math.normalized(new Vec4(this));
@@ -196,6 +220,8 @@ public class Vec4 implements Vector4, Equatable<Vector4>, Copyable<Vec4> {
      *
      * @param addendum vector to add
      * @return current vector increased by {@code addendum} vector
+     *
+     * @since 1.0.0
      */
     public Vector4 add(final Vector4 addendum) {
         return Vec4Math.add(this, addendum);
@@ -208,6 +234,8 @@ public class Vec4 implements Vector4, Equatable<Vector4>, Copyable<Vec4> {
      * @param addendum vector to add
      * @return new vector with sum of components of current vector and
      *         {@code addendum} vector
+     *
+     * @since 1.0.0
      */
     public Vector4 added(final Vector4 addendum) {
         return Vec4Math.added(this, addendum);
@@ -219,6 +247,8 @@ public class Vec4 implements Vector4, Equatable<Vector4>, Copyable<Vec4> {
      * 
      * @param subtrahend vector to subtract
      * @return current vector subtracted by {@code subtrahend} vector
+     *
+     * @since 1.0.0
      */
     public Vector4 sub(final Vector4 subtrahend) {
         return Vec4Math.sub(this, subtrahend);
@@ -231,6 +261,8 @@ public class Vec4 implements Vector4, Equatable<Vector4>, Copyable<Vec4> {
      * @param subtrahend vector to subtract
      * @return new vector with components resulting current vector subtracted
      *         by {@code subtrahend} vector
+     *
+     * @since 1.0.0
      */
     public Vector4 subtracted(final Vector4 subtrahend) {
         return Vec4Math.subtracted(this, subtrahend);
@@ -241,6 +273,8 @@ public class Vec4 implements Vector4, Equatable<Vector4>, Copyable<Vec4> {
      *
      * @param v second vector
      * @return dot (scalar) product of vectors
+     *
+     * @since 1.0.0
      */
     public float dot(final Vector4 v) {
         return Vec4Math.dot(this, v);
@@ -292,6 +326,8 @@ public class Vec4 implements Vector4, Equatable<Vector4>, Copyable<Vec4> {
      * Constructs new vector of size 4 with all 0 components.
      * 
      * @return new zero vector of size 4
+     *
+     * @since 1.0.0
      */
     public static Vector4 zeroVector() {
         return new Vec4();
@@ -301,6 +337,8 @@ public class Vec4 implements Vector4, Equatable<Vector4>, Copyable<Vec4> {
      * Constructs new vector of size 4 with all 1 components.
      * 
      * @return new unit vector of size 4
+     *
+     * @since 1.0.0
      */
     public static Vector4 unitVector() {
         return Vec4Math.unitVec();

--- a/lib/src/main/java/io/github/alphameo/linear_algebra/vec/Vec4Math.java
+++ b/lib/src/main/java/io/github/alphameo/linear_algebra/vec/Vec4Math.java
@@ -4,11 +4,15 @@ import io.github.alphameo.linear_algebra.Validator;
 
 /**
  * Class with static functions for vectors of size 4.
+ *
+ * @since 1.0.0
  */
 public final class Vec4Math {
 
     /**
      * Default empty constructor
+     *
+     * @since 1.0.0
      */
     public Vec4Math() {
     }
@@ -20,6 +24,8 @@ public final class Vec4Math {
      * 
      * @param v vector of size 4 for square length calculation
      * @return square length of given vector
+     *
+     * @since 1.0.0
      */
     public static float len2(final Vector4 v) {
         return v.x() * v.x() + v.y() * v.y() + v.z() * v.z() + v.w() * v.w();
@@ -30,6 +36,8 @@ public final class Vec4Math {
      * 
      * @param v vector of size 4 for length calculation
      * @return length of given vector
+     *
+     * @since 1.0.0
      */
     public static float len(final Vector4 v) {
         return (float) Math.sqrt(len2(v));
@@ -41,6 +49,8 @@ public final class Vec4Math {
      * @param v          vector of size 4 for multiplication
      * @param multiplier scalar value
      * @return given vector with multiplied components
+     *
+     * @since 1.0.0
      */
     public static Vector4 mult(final Vector4 v, final float multiplier) {
         v.setX(v.x() * multiplier);
@@ -58,6 +68,8 @@ public final class Vec4Math {
      * @param v          vector of size 4 for multiplication
      * @param multiplier scalar value
      * @return new vector of size 4 with multiplied components of given vector
+     *
+     * @since 1.0.0
      */
     public static Vector4 multiplied(final Vector4 v, final float multiplier) {
         return mult(new Vec4(v), multiplier);
@@ -70,6 +82,8 @@ public final class Vec4Math {
      * @param divisor scalar value
      * @return given vector with divided components
      * @throws ArithmeticException if {@code divisor} approximately equal to 0
+     *
+     * @since 1.0.0
      */
     public static Vector4 divide(final Vector4 v, final float divisor) throws ArithmeticException {
         Validator.validateDivisor(divisor);
@@ -89,6 +103,8 @@ public final class Vec4Math {
      * @param divisor scalar value
      * @return new vector of size 4 with divided components of given vector
      * @throws ArithmeticException if {@code divisor} approximately equal to 0
+     *
+     * @since 1.0.0
      */
     public static Vector4 divided(final Vector4 v, final float divisor) throws ArithmeticException {
         return divide(new Vec4(v), divisor);
@@ -100,6 +116,8 @@ public final class Vec4Math {
      * @param v vector of size 4 to be normalized
      * @return given vector with normalized components
      * @throws ArithmeticException if length of given vector equals 0
+     *
+     * @since 1.0.0
      */
     public static Vector4 normalize(final Vector4 v) throws ArithmeticException {
         return divide(v, len(v));
@@ -111,6 +129,8 @@ public final class Vec4Math {
      * @param v vector of size 4 to be normalized
      * @return new vector of size 4 with normalized components of given vector
      * @throws ArithmeticException if length of given vector equals 0
+     *
+     * @since 1.0.0
      */
     public static Vector4 normalized(final Vector4 v) throws ArithmeticException {
         return divided(v, len(v));
@@ -123,6 +143,8 @@ public final class Vec4Math {
      * @param target   vector of size 4 to be added
      * @param addendum vector of size 4 to add
      * @return {@code target} vector increased by {@code addendum} vector
+     *
+     * @since 1.0.0
      */
     public static Vector4 add(final Vector4 target, final Vector4 addendum) {
         target.setX(target.x() + addendum.x());
@@ -142,6 +164,8 @@ public final class Vec4Math {
      * @return new vector of size 4 with sum of components of {@code target} vector
      *         and
      *         {@code addendum} vector
+     *
+     * @since 1.0.0
      */
     public static Vector4 added(final Vector4 target, final Vector4 addendum) {
         return add(new Vec4(target), addendum);
@@ -154,6 +178,8 @@ public final class Vec4Math {
      * @param target     vector of size 4 to be subtracted
      * @param subtrahend vector of size 4 to subtract
      * @return {@code target} vector subtracted by {@code subtrahend} vector
+     *
+     * @since 1.0.0
      */
     public static Vector4 sub(final Vector4 target, final Vector4 subtrahend) {
         target.setX(target.x() - subtrahend.x());
@@ -172,6 +198,8 @@ public final class Vec4Math {
      * @param subtrahend vector of size 4 to subtract
      * @return new vector of size 4 with components resulting {@code target} vector
      *         subtracted by {@code subtrahend} vector
+     *
+     * @since 1.0.0
      */
     public static Vector4 subtracted(final Vector4 target, final Vector4 subtrahend) {
         return sub(new Vec4(target), subtrahend);
@@ -183,6 +211,8 @@ public final class Vec4Math {
      * @param v1 first vector of size 4
      * @param v2 second vector of size 4
      * @return dot (scalar) product of given vectors
+     *
+     * @since 1.0.0
      */
     public static float dot(final Vector4 v1, final Vector4 v2) {
         return v1.x() * v2.x() + v1.y() * v2.y() + v1.z() * v2.z() + v1.w() * v2.w();
@@ -197,6 +227,8 @@ public final class Vec4Math {
      * @param eps tolerance
      * @return {@code true} if all components of vectors are equal within
      *         {@code epsilon} tolerance, and {@code false} otherwise
+     *
+     * @since 1.0.0
      */
     public static boolean equalsEpsilon(final Vector4 v1, final Vector4 v2, final float eps) {
         return Validator.equalsEpsilon(v1.x(), v2.x(), eps)
@@ -212,6 +244,8 @@ public final class Vec4Math {
      * @param v2 second vector of size 4 for comparison
      * @return {@code true} if all components of vectors are approximately equal,
      *         and {@code false} otherwise
+     *
+     * @since 1.0.0
      */
     public static boolean equals(final Vector4 v1, final Vector4 v2) {
         return equalsEpsilon(v1, v2, Validator.EPS);
@@ -221,6 +255,8 @@ public final class Vec4Math {
      * Constructs new vector of size 4 with all 0 components.
      * 
      * @return new zero vector of size 4
+     *
+     * @since 1.0.0
      */
     public static Vector4 zeroVec() {
         return new Vec4();
@@ -230,6 +266,8 @@ public final class Vec4Math {
      * Constructs new vector of size 4 with all 1 components.
      * 
      * @return new unit vector of size 4
+     *
+     * @since 1.0.0
      */
     public static Vector4 unitVec() {
         return new Vec4(1, 1, 1, 1);

--- a/lib/src/main/java/io/github/alphameo/linear_algebra/vec/VecMath.java
+++ b/lib/src/main/java/io/github/alphameo/linear_algebra/vec/VecMath.java
@@ -4,11 +4,15 @@ import io.github.alphameo.linear_algebra.Validator;
 
 /**
  * Class with static functions for arbitrary vectors.
+ *
+ * @since 1.0.0
  */
 public final class VecMath {
 
     /**
      * Default empty constructor
+     *
+     * @since 1.0.0
      */
     public VecMath() {
     }
@@ -20,6 +24,8 @@ public final class VecMath {
      * 
      * @param v vector for square length calculation
      * @return square length of given vector
+     *
+     * @since 1.0.0
      */
     public static float len2(final Vector v) {
         float sum = 0;
@@ -35,6 +41,8 @@ public final class VecMath {
      * 
      * @param v vector for length calculation
      * @return length of given vector
+     *
+     * @since 1.0.0
      */
     public static float len(final Vector v) {
         return (float) Math.sqrt(len2(v));
@@ -46,6 +54,8 @@ public final class VecMath {
      * @param v          vector for multiplication
      * @param multiplier scalar value
      * @return given vector with multiplied components
+     *
+     * @since 1.0.0
      */
     public static Vector mult(final Vector v, final float multiplier) {
         for (int i = 0; i < v.size(); i++) {
@@ -62,6 +72,8 @@ public final class VecMath {
      * @param v          vector for multiplication
      * @param multiplier scalar value
      * @return new vector with multiplied components of given vector
+     *
+     * @since 1.0.0
      */
     public static Vector multiplied(final Vector v, final float multiplier) {
         return mult(new Vec(v), multiplier);
@@ -74,6 +86,8 @@ public final class VecMath {
      * @param divisor scalar value
      * @return given vector with divided components
      * @throws ArithmeticException if {@code divisor} approximately equal to 0
+     *
+     * @since 1.0.0
      */
     public static Vector divide(final Vector v, final float divisor) throws ArithmeticException {
         Validator.validateDivisor(divisor);
@@ -91,6 +105,8 @@ public final class VecMath {
      * @param divisor scalar value
      * @return new vector with divided components of given vector
      * @throws ArithmeticException if {@code divisor} approximately equal to 0
+     *
+     * @since 1.0.0
      */
     public static Vector divided(final Vector v, final float divisor) throws ArithmeticException {
         return divide(new Vec(v), divisor);
@@ -102,6 +118,8 @@ public final class VecMath {
      * @param v vector to be normalized
      * @return given vector with normalized components
      * @throws ArithmeticException if length of given vector equals 0
+     *
+     * @since 1.0.0
      */
     public static Vector normalize(final Vector v) throws ArithmeticException {
         return divide(v, len(v));
@@ -113,6 +131,8 @@ public final class VecMath {
      * @param v vector to be normalized
      * @return new vector with normalized components of given vector
      * @throws ArithmeticException if length of given vector equals 0
+     *
+     * @since 1.0.0
      */
     public static Vector normalized(final Vector v) throws ArithmeticException {
         return divided(v, len(v));
@@ -126,6 +146,8 @@ public final class VecMath {
      * @param addendum vector to add
      * @return {@code target} vector increased by {@code addendum} vector
      * @throws IllegalArgumentException if given vectors have different sizes
+     *
+     * @since 1.0.0
      */
     public static Vector add(final Vector target, final Vector addendum) {
         Validator.validateVectorSizes(target, addendum, "Addition denied");
@@ -145,6 +167,8 @@ public final class VecMath {
      * @return new vector with sum of components of {@code target} vector and
      *         {@code addendum} vector
      * @throws IllegalArgumentException if given vectors have different sizes
+     *
+     * @since 1.0.0
      */
     public static Vector added(final Vector target, final Vector addendum) {
         return add(new Vec(target), addendum);
@@ -158,6 +182,8 @@ public final class VecMath {
      * @param subtrahend vector to subtract
      * @return {@code target} vector subtracted by {@code subtrahend} vector
      * @throws IllegalArgumentException if given vectors have different sizes
+     *
+     * @since 1.0.0
      */
     public static Vector sub(final Vector target, final Vector subtrahend) {
         Validator.validateVectorSizes(target, subtrahend, "Subtraction denied");
@@ -177,6 +203,8 @@ public final class VecMath {
      * @return new vector with components resulting {@code target} vector subtracted
      *         by {@code subtrahend} vector
      * @throws IllegalArgumentException if given vectors have different sizes
+     *
+     * @since 1.0.0
      */
     public static Vector subtracted(final Vector target, final Vector subtrahend) {
         return sub(new Vec(target), subtrahend);
@@ -188,6 +216,8 @@ public final class VecMath {
      * @param v1 first vector
      * @param v2 second vector
      * @return dot (scalar) product of given vectors
+     *
+     * @since 1.0.0
      */
     public static float dot(final Vector v1, final Vector v2) {
         Validator.validateVectorSizes(v1, v2, "Scalar product denied");
@@ -206,6 +236,8 @@ public final class VecMath {
      * @param v2 second vector
      * @return vector, which represents cross (vector) product of given vectors
      * @throws IllegalArgumentException if vectors' sizes are not equal 3
+     *
+     * @since 1.0.0
      */
     public static Vector cross(final Vector v1, final Vector v2) {
         if (v1.size() != 3 || v2.size() != 3) {
@@ -230,6 +262,8 @@ public final class VecMath {
      * @param eps tolerance
      * @return {@code true} if all components of vectors are equal within
      *         {@code epsilon} tolerance, and {@code false} otherwise
+     *
+     * @since 1.0.0
      */
     public static boolean equalsEpsilon(final Vector v1, final Vector v2, final float eps) {
         Validator.validateVectorSizes(v1, v2, "Equalization denied");
@@ -249,6 +283,8 @@ public final class VecMath {
      * @param v2 second vector for comparison
      * @return {@code true} if all components of vectors are approximately equal,
      *         and {@code false} otherwise
+     *
+     * @since 1.0.0
      */
     public static boolean equals(final Vector v1, final Vector v2) {
         return equalsEpsilon(v1, v2, Validator.EPS);
@@ -259,6 +295,8 @@ public final class VecMath {
      * 
      * @param size size of vector to be constructed
      * @return new zero vector of given {@code size}
+     *
+     * @since 1.0.0
      */
     public static Vector zeroVec(final int size) {
         return new Vec(size);
@@ -269,6 +307,8 @@ public final class VecMath {
      * 
      * @param size size of vector to be constructed
      * @return new unit vector of given {@code size}
+     *
+     * @since 1.0.0
      */
     public static Vector unitVec(final int size) {
         final Vector result = new Vec(size);

--- a/lib/src/main/java/io/github/alphameo/linear_algebra/vec/Vector.java
+++ b/lib/src/main/java/io/github/alphameo/linear_algebra/vec/Vector.java
@@ -2,6 +2,8 @@ package io.github.alphameo.linear_algebra.vec;
 
 /**
  * Interface for arbitrary vector.
+ *
+ * @since 1.0.0
  */
 public interface Vector {
 
@@ -10,6 +12,8 @@ public interface Vector {
      * 
      * @param i position index of component
      * @return component at given position
+     *
+     * @since 1.0.0
      */
     public float get(int i);
 
@@ -18,6 +22,8 @@ public interface Vector {
      *
      * @param i     position index for putting value
      * @param value component value to be put
+     *
+     * @since 1.0.0
      */
     public void set(int i, final float value);
 
@@ -25,6 +31,8 @@ public interface Vector {
      * Returns size (components count) of vector.
      * 
      * @return size of vector
+     *
+     * @since 1.0.0
      */
     public int size();
 }

--- a/lib/src/main/java/io/github/alphameo/linear_algebra/vec/Vector2.java
+++ b/lib/src/main/java/io/github/alphameo/linear_algebra/vec/Vector2.java
@@ -2,6 +2,8 @@ package io.github.alphameo.linear_algebra.vec;
 
 /**
  * Interface for vector of size 2.
+ *
+ * @since 1.0.0
  */
 public interface Vector2 extends Vector {
 
@@ -9,6 +11,8 @@ public interface Vector2 extends Vector {
      * Returns x component (index = 0) of vector with size 2.
      * 
      * @return x component of vector with size 2
+     *
+     * @since 1.0.0
      */
     float x();
 
@@ -16,6 +20,8 @@ public interface Vector2 extends Vector {
      * Returns x component (index = 1) of vector with size 2.
      * 
      * @return x component of vector with size 2
+     *
+     * @since 1.0.0
      */
     float y();
 
@@ -23,6 +29,8 @@ public interface Vector2 extends Vector {
      * Sets value of x component (index = 0) inside vector.
      *
      * @param value component value to be set
+     *
+     * @since 1.0.0
      */
     void setX(float value);
 
@@ -30,6 +38,8 @@ public interface Vector2 extends Vector {
      * Sets value of x component (index = 1) inside vector.
      *
      * @param value component value to be set
+     *
+     * @since 1.0.0
      */
     void setY(float value);
 }

--- a/lib/src/main/java/io/github/alphameo/linear_algebra/vec/Vector3.java
+++ b/lib/src/main/java/io/github/alphameo/linear_algebra/vec/Vector3.java
@@ -2,6 +2,8 @@ package io.github.alphameo.linear_algebra.vec;
 
 /**
  * Interface for vector of size 3.
+ *
+ * @since 1.0.0
  */
 public interface Vector3 extends Vector {
 
@@ -9,6 +11,8 @@ public interface Vector3 extends Vector {
      * Returns x component (index = 0).
      * 
      * @return x component of vector
+     *
+     * @since 1.0.0
      */
     float x();
 
@@ -16,6 +20,8 @@ public interface Vector3 extends Vector {
      * Returns x component (index = 1).
      * 
      * @return x component of vector
+     *
+     * @since 1.0.0
      */
     float y();
 
@@ -23,6 +29,8 @@ public interface Vector3 extends Vector {
      * Returns z component (index = 2).
      * 
      * @return z component of vector
+     *
+     * @since 1.0.0
      */
     float z();
 
@@ -30,6 +38,8 @@ public interface Vector3 extends Vector {
      * Sets value of x component (index = 0) inside vector.
      *
      * @param value component value to be set
+     *
+     * @since 1.0.0
      */
     void setX(float value);
 
@@ -37,6 +47,8 @@ public interface Vector3 extends Vector {
      * Sets value of y component (index = 1) inside vector.
      *
      * @param value component value to be set
+     *
+     * @since 1.0.0
      */
     void setY(float value);
 
@@ -44,6 +56,8 @@ public interface Vector3 extends Vector {
      * Sets value of z component (index = 2) inside vector.
      *
      * @param value component value to be set
+     *
+     * @since 1.0.0
      */
     void setZ(float value);
 }

--- a/lib/src/main/java/io/github/alphameo/linear_algebra/vec/Vector4.java
+++ b/lib/src/main/java/io/github/alphameo/linear_algebra/vec/Vector4.java
@@ -2,6 +2,8 @@ package io.github.alphameo.linear_algebra.vec;
 
 /**
  * Interface for vector of size 4.
+ *
+ * @since 1.0.0
  */
 public interface Vector4 extends Vector {
 
@@ -9,6 +11,8 @@ public interface Vector4 extends Vector {
      * Returns x component (index = 0).
      * 
      * @return x component of vector
+     *
+     * @since 1.0.0
      */
     float x();
 
@@ -16,6 +20,8 @@ public interface Vector4 extends Vector {
      * Returns y component (index = 1).
      * 
      * @return y component of vector
+     *
+     * @since 1.0.0
      */
     float y();
 
@@ -23,6 +29,8 @@ public interface Vector4 extends Vector {
      * Returns z component (index = 2).
      * 
      * @return z component of vector
+     *
+     * @since 1.0.0
      */
     float z();
 
@@ -30,6 +38,8 @@ public interface Vector4 extends Vector {
      * Returns w component (index = 3).
      * 
      * @return w component of vector
+     *
+     * @since 1.0.0
      */
     float w();
 
@@ -37,6 +47,8 @@ public interface Vector4 extends Vector {
      * Sets value of x component (index = 0) inside vector.
      *
      * @param value component value to be set
+     *
+     * @since 1.0.0
      */
     void setX(float value);
 
@@ -44,6 +56,8 @@ public interface Vector4 extends Vector {
      * Sets value of y component (index = 1) inside vector.
      *
      * @param value component value to be set
+     *
+     * @since 1.0.0
      */
     void setY(float value);
 
@@ -51,6 +65,8 @@ public interface Vector4 extends Vector {
      * Sets value of z component (index = 2) inside vector.
      *
      * @param value component value to be set
+     *
+     * @since 1.0.0
      */
     void setZ(float value);
 
@@ -58,6 +74,8 @@ public interface Vector4 extends Vector {
      * Sets value of w component (index = 3) inside vector.
      *
      * @param value component value to be set
+     *
+     * @since 1.0.0
      */
     void setW(float value);
 }

--- a/lib/src/main/java/io/github/alphameo/linear_algebra/vec/package-info.java
+++ b/lib/src/main/java/io/github/alphameo/linear_algebra/vec/package-info.java
@@ -1,4 +1,6 @@
 /**
  * Package for Vector math.
+ *
+ * @since 1.0.0
  */
 package io.github.alphameo.linear_algebra.vec;


### PR DESCRIPTION
it's a good tone to add the `@since` to all the javadocs of public API's.

as a version to the tags i picked the version of last (and first stable/major) release.