### PR TITLE
docs: module-info

### DIFF
--- a/lib/src/main/java/module-info.java
+++ b/lib/src/main/java/module-info.java
@@ -1,5 +1,7 @@
-/*
+/**
  * Java library for Linear algebra
+ *
+ * @version 1.0.0
  */
 module io.github.alphameo.linear_algebra {
     // matrices


### PR DESCRIPTION
1. the "javadoc" was a regular comment because of the missing asterisk
2. add version tag with the latest library version